### PR TITLE
Do not check in API secrets in discord webhook urls

### DIFF
--- a/github/main.tf
+++ b/github/main.tf
@@ -10,7 +10,7 @@ provider "github" {
 
 resource "github_organization_webhook" "discord" {
   configuration {
-    url          = "https://discordapp.com/api/webhooks/608192305341399041/${var.discord_api_secret}/github"
+    url          = "https://discordapp.com/api/webhooks/616536749367099402/${var.discord_api_secret}/github"
     content_type = "json"
     insecure_ssl = 0
   }

--- a/github/main.tf
+++ b/github/main.tf
@@ -1,4 +1,5 @@
 variable "github_token" {}
+variable "discord_api_secret" {}
 
 provider "github" {
   version = "~> 2.2"
@@ -9,7 +10,7 @@ provider "github" {
 
 resource "github_organization_webhook" "discord" {
   configuration {
-    url          = "https://discordapp.com/api/webhooks/608192305341399041/oc9Q3GcyBwJwQz9YIMHg4g4ZL28JAEO7qdRKqVgQUkxXm0kXvvn2WbSspWNyX3TVz8-p/github"
+    url          = "https://discordapp.com/api/webhooks/608192305341399041/${var.discord_api_secret}/github"
     content_type = "json"
     insecure_ssl = 0
   }


### PR DESCRIPTION
GitGuardian alerted on 58d5ea3112324de35d9f2c77be214ad9087af269 which added the discord webhook.

Discord webhook URLs contain an API secret.

This PR factors out the API key to a secret.
The old webhook has been revoked.