### PR TITLE
Store terraform state remotely in an S3 bucket

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,12 +18,31 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+
+      - name: "Terraform Format"
+        uses: hashicorp/terraform-github-actions@master
+        with:
+          tf_actions_version: 0.12.13
+          tf_actions_subcommand: "fmt"
+          tf_actions_working_dir: "aws"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: "Terraform Format"
         uses: hashicorp/terraform-github-actions@master
         with:
           tf_actions_version: 0.12.13
           tf_actions_subcommand: "fmt"
           tf_actions_working_dir: "github"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: "Terraform Format"
+        uses: hashicorp/terraform-github-actions@master
+        with:
+          tf_actions_version: 0.12.13
+          tf_actions_subcommand: "fmt"
+          tf_actions_working_dir: "remote-state"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/aws/aws.tf
+++ b/aws/aws.tf
@@ -1,0 +1,9 @@
+variable "region" {
+  default = "us-west-2"
+}
+
+provider "aws" {
+  region  = var.region
+  version = "~> 2.17"
+  profile = "artichokeruby"
+}

--- a/aws/dns.tf
+++ b/aws/dns.tf
@@ -1,0 +1,1 @@
+# DNS is managed by Google Domains (registrar of Artichoke domains)

--- a/aws/email.tf
+++ b/aws/email.tf
@@ -1,0 +1,1 @@
+# email is configured using the G Suite integration in Google Domains

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -25,7 +25,7 @@ data "aws_iam_policy_document" "admin" {
 
     effect = "Allow"
 
-    actions =   ["*"]
+    actions   = ["*"]
     resources = ["*"]
   }
 }

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -1,0 +1,75 @@
+terraform {
+  backend "s3" {
+    bucket         = "artichoke-terraform-state"
+    region         = "us-west-2"
+    key            = "aws/terraform.tfstate"
+    encrypt        = true
+    dynamodb_table = "terraform_statelock"
+
+    profile = "artichokeruby"
+  }
+}
+
+
+variable "name" {
+  default = "artichokeruby"
+}
+
+variable "iam_admins" {
+  default = "lopopolo"
+}
+
+data "aws_iam_policy_document" "admin" {
+  statement {
+    sid = 1
+
+    effect = "Allow"
+
+    actions =   ["*"]
+    resources = ["*"]
+  }
+}
+
+module "iam_admin" {
+  source = "./modules/util/iam"
+
+  name  = "${var.name}-admin"
+  users = var.iam_admins
+
+  policy = data.aws_iam_policy_document.admin.json
+}
+
+output "config" {
+  value = <<CONFIG
+
+Admin IAM:
+  Admin Users: ${join(
+  "\n               ",
+  formatlist("%s", split(",", module.iam_admin.users)),
+  )}
+
+  Access IDs: ${join(
+  "\n              ",
+  formatlist("%s", split(",", module.iam_admin.access_ids)),
+  )}
+
+  Secret Keys: ${join(
+  "\n               ",
+  formatlist("%s", split(",", module.iam_admin.secret_keys)),
+)}
+
+CONFIG
+
+}
+
+output "iam_admin_users" {
+  value = module.iam_admin.users
+}
+
+output "iam_admin_access_ids" {
+  value = module.iam_admin.access_ids
+}
+
+output "iam_admin_secret_keys" {
+  value = module.iam_admin.secret_keys
+}

--- a/aws/modules/network/management/main.tf
+++ b/aws/modules/network/management/main.tf
@@ -1,0 +1,155 @@
+variable "name" {}
+
+variable "vpc_id" {}
+variable "azs" {}
+variable "internet_gateway_id" {}
+variable "egress_gateway_id" {}
+
+variable "s3_route_tables" {
+  type = list
+}
+
+module "tier" {
+  source = "../subnet_tier"
+}
+
+module "public_subnet" {
+  source = "../public_subnet"
+
+  name   = "${var.name}-public"
+  vpc_id = "${var.vpc_id}"
+  azs    = "${var.azs}"
+
+  subnet_tier         = "${module.tier.management_public}"
+  internet_gateway_id = "${var.internet_gateway_id}"
+  egress_gateway_id   = "${var.egress_gateway_id}"
+}
+
+module "private_subnet" {
+  source = "../private_subnet"
+
+  name   = "${var.name}-private"
+  vpc_id = "${var.vpc_id}"
+  azs    = "${var.azs}"
+
+  subnet_tier       = "${module.tier.management_private}"
+  nat_enabled       = "false"
+  nat_gateway_ids   = ""
+  egress_gateway_id = "${var.egress_gateway_id}"
+}
+
+resource "aws_security_group" "this" {
+  name_prefix = "management-sg-"
+  description = "Management Domain Security Group"
+  vpc_id      = var.vpc_id
+
+  egress {
+    from_port       = 80
+    to_port         = 80
+    protocol        = "tcp"
+    security_groups = ["${aws_security_group.ssm.id}"]
+  }
+
+  egress {
+    from_port       = 443
+    to_port         = 443
+    protocol        = "tcp"
+    security_groups = ["${aws_security_group.ssm.id}"]
+  }
+
+  egress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port        = 80
+    to_port          = 80
+    protocol         = "tcp"
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  egress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port        = 443
+    to_port          = 443
+    protocol         = "tcp"
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port        = 22
+    to_port          = 22
+    protocol         = "tcp"
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  tags = {
+    Class = "management"
+  }
+}
+
+data "aws_vpc_endpoint_service" "s3" {
+  service = "s3"
+}
+
+resource "aws_vpc_endpoint" "s3" {
+  vpc_id          = "${var.vpc_id}"
+  service_name    = "${data.aws_vpc_endpoint_service.s3.service_name}"
+  route_table_ids = concat(var.s3_route_tables, module.public_subnet.route_table, module.private_subnet.route_table)
+}
+
+data "aws_vpc_endpoint_service" "ssm" {
+  service = "ssm"
+}
+
+resource "aws_security_group" "ssm" {
+  name_prefix = "ssm-sg-"
+  description = "SSM VPC Endpoint Security Group"
+  vpc_id      = "${var.vpc_id}"
+}
+
+resource "aws_security_group_rule" "ssm_endpoint_from_management" {
+  type                     = "ingress"
+  protocol                 = "-1"
+  from_port                = 0
+  to_port                  = 0
+  security_group_id        = "${aws_security_group.ssm.id}"
+  source_security_group_id = "${aws_security_group.this.id}"
+}
+
+resource "aws_vpc_endpoint" "ssm" {
+  vpc_id              = "${var.vpc_id}"
+  service_name        = "${data.aws_vpc_endpoint_service.ssm.service_name}"
+  vpc_endpoint_type   = "Interface"
+  subnet_ids          = module.private_subnet.subnet_ids
+  security_group_ids  = ["${aws_security_group.ssm.id}"]
+  private_dns_enabled = true
+}
+
+output "s3_endpoint_prefix_list_id" {
+  value = "${aws_vpc_endpoint.s3.prefix_list_id}"
+}
+
+output "ssm_security_group_id" {
+  value = "${aws_security_group.ssm.id}"
+}
+
+output "build_subnet_ids" {
+  value = "${join(",", module.public_subnet.subnet_ids)}"
+}

--- a/aws/modules/network/nat/nat.tf
+++ b/aws/modules/network/nat/nat.tf
@@ -1,0 +1,52 @@
+#--------------------------------------------------------------
+# This module creates all resources necessary for NAT
+#--------------------------------------------------------------
+
+variable "name" {
+  default = "nat"
+}
+
+variable "enabled" {
+  default = "true"
+}
+
+variable "vpc_id" {
+}
+
+variable "public_subnet_tier" {
+}
+
+data "aws_vpc" "selected" {
+  id = var.vpc_id
+}
+
+data "aws_subnet_ids" "public" {
+  vpc_id = data.aws_vpc.selected.id
+
+  tags = {
+    Network = var.public_subnet_tier
+  }
+}
+
+resource "aws_eip" "nat" {
+  count = var.enabled == "true" ? 1 : 0
+  vpc   = true
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_nat_gateway" "nat" {
+  count         = var.enabled == "true" ? 1 : 0
+  allocation_id = element(aws_eip.nat.*.id, count.index)
+  subnet_id     = data.aws_subnet_ids.public.ids[count.index]
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+output "nat_gateway_ids" {
+  value = join(",", aws_nat_gateway.nat.*.id)
+}

--- a/aws/modules/network/network.tf
+++ b/aws/modules/network/network.tf
@@ -1,0 +1,161 @@
+#--------------------------------------------------------------
+# This module creates all networking resources
+#--------------------------------------------------------------
+
+variable "name" {
+}
+
+variable "vpc_cidr" {
+}
+
+variable "azs" {
+}
+
+variable "nat_enabled" {
+}
+
+variable "region" {
+}
+
+module "vpc" {
+  source = "./vpc"
+
+  name = "${var.name}-vpc"
+  cidr = var.vpc_cidr
+}
+
+module "tier" {
+  source = "./subnet_tier"
+}
+
+module "public_subnet" {
+  source = "./public_subnet"
+
+  name   = "${var.name}-public"
+  vpc_id = module.vpc.vpc_id
+  azs    = var.azs
+
+  subnet_tier         = module.tier.public
+  internet_gateway_id = module.vpc.internet_gateway_id
+  egress_gateway_id   = module.vpc.egress_gateway_id
+}
+
+module "private_subnet" {
+  source = "./private_subnet"
+
+  name   = "${var.name}-private"
+  vpc_id = module.vpc.vpc_id
+  azs    = var.azs
+
+  subnet_tier       = module.tier.private
+  nat_enabled       = var.nat_enabled
+  nat_gateway_ids   = module.nat.nat_gateway_ids
+  egress_gateway_id = module.vpc.egress_gateway_id
+}
+
+module "nat" {
+  source = "./nat"
+
+  enabled            = var.nat_enabled
+  name               = "${var.name}-nat"
+  vpc_id             = module.vpc.vpc_id
+  public_subnet_tier = module.public_subnet.tier
+}
+
+module "management" {
+  source = "./management"
+
+  name                = "${var.name}-management"
+  vpc_id              = module.vpc.vpc_id
+  azs                 = var.azs
+  internet_gateway_id = module.vpc.internet_gateway_id
+  egress_gateway_id   = module.vpc.egress_gateway_id
+  s3_route_tables = concat(
+    module.public_subnet.route_table,
+    module.private_subnet.route_table,
+  )
+}
+
+resource "aws_network_acl" "acl" {
+  vpc_id = module.vpc.vpc_id
+
+  ingress {
+    protocol   = "-1"
+    rule_no    = 100
+    action     = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 0
+    to_port    = 0
+  }
+
+  ingress {
+    protocol        = "-1"
+    rule_no         = 200
+    action          = "allow"
+    ipv6_cidr_block = "::/0"
+    from_port       = 0
+    to_port         = 0
+  }
+
+  egress {
+    protocol   = "-1"
+    rule_no    = 100
+    action     = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 0
+    to_port    = 0
+  }
+
+  egress {
+    protocol        = "-1"
+    rule_no         = 200
+    action          = "allow"
+    ipv6_cidr_block = "::/0"
+    from_port       = 0
+    to_port         = 0
+  }
+
+  tags = {
+    Name = "${var.name}-all"
+  }
+}
+
+# VPC
+output "vpc_id" {
+  value = module.vpc.vpc_id
+}
+
+output "vpc_cidr" {
+  value = module.vpc.vpc_cidr
+}
+
+output "egress_gateway_id" {
+  value = module.vpc.egress_gateway_id
+}
+
+# Subnets
+output "public_subnet_tier" {
+  value = module.public_subnet.tier
+}
+
+output "private_subnet_tier" {
+  value = module.private_subnet.tier
+}
+
+output "build_subnet_ids" {
+  value = module.management.build_subnet_ids
+}
+
+# NAT
+output "nat_gateway_ids" {
+  value = module.nat.nat_gateway_ids
+}
+
+# VPC Endpoints
+output "s3_endpoint_prefix_list_id" {
+  value = module.management.s3_endpoint_prefix_list_id
+}
+
+output "ssm_security_group_id" {
+  value = module.management.ssm_security_group_id
+}

--- a/aws/modules/network/private_subnet/private_subnet.tf
+++ b/aws/modules/network/private_subnet/private_subnet.tf
@@ -1,0 +1,103 @@
+#--------------------------------------------------------------
+# This module creates all resources necessary for a private
+# subnet
+#--------------------------------------------------------------
+
+variable "name" {}
+
+variable "vpc_id" {}
+variable "azs" {}
+
+variable "nat_enabled" {
+  # https://www.terraform.io/docs/configuration/variables.html#booleans
+  type    = "string"
+  default = "true"
+}
+
+variable "nat_gateway_ids" {}
+variable "egress_gateway_id" {}
+
+variable "subnet_tier" {}
+
+data "aws_vpc" "this" {
+  id = "${var.vpc_id}"
+}
+
+resource "aws_subnet" "private" {
+  vpc_id            = "${data.aws_vpc.this.id}"
+  cidr_block        = "${cidrsubnet(cidrsubnet(data.aws_vpc.this.cidr_block, 3, var.subnet_tier), 5, count.index)}"
+  availability_zone = "${element(split(",", var.azs), count.index)}"
+  count             = "${length(split(",", var.azs))}"
+
+  ipv6_cidr_block                 = "${cidrsubnet(cidrsubnet(data.aws_vpc.this.ipv6_cidr_block, 3, var.subnet_tier), 5, count.index)}"
+  assign_ipv6_address_on_creation = true
+
+  tags = {
+    Name    = "${var.name}.${element(split(",", var.azs), count.index)}"
+    Network = "subnet-tier-${var.subnet_tier}"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_route_table" "private" {
+  vpc_id = "${data.aws_vpc.this.id}"
+  count  = "${length(split(",", var.azs))}"
+
+  tags = {
+    Name = "${var.name}.${element(split(",", var.azs), count.index)}"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_route" "nat_gateway" {
+  count = "${var.nat_enabled == "true" ? length(split(",", var.azs)) : 0}"
+
+  route_table_id         = aws_route_table.private[count.index].id
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id         = "${element(split(",", var.nat_gateway_ids), count.index)}"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_route" "ipv6_egress_gateway" {
+  count = "${var.nat_enabled == "true" ? length(split(",", var.azs)) : 0}"
+
+  route_table_id         = aws_route_table.private[count.index].id
+  destination_cidr_block = "::/0"
+  egress_only_gateway_id = "${var.egress_gateway_id}"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_route_table_association" "private" {
+  count          = "${length(split(",", var.azs))}"
+  subnet_id      = aws_subnet.private[count.index].id
+  route_table_id = aws_route_table.private[count.index].id
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+output "subnet_ids" {
+  value = "${aws_subnet.private.*.id}"
+}
+
+output "tier" {
+  value      = "subnet-tier-${var.subnet_tier}"
+  depends_on = [aws_subnet.private]
+}
+
+output "route_table" {
+  value = "${aws_route_table.private.*.id}"
+}

--- a/aws/modules/network/public_subnet/public_subnet.tf
+++ b/aws/modules/network/public_subnet/public_subnet.tf
@@ -1,0 +1,76 @@
+#--------------------------------------------------------------
+# This module creates all resources necessary for a public
+# subnet
+#--------------------------------------------------------------
+
+variable "name" {}
+
+variable "vpc_id" {}
+variable "azs" {}
+variable "internet_gateway_id" {}
+variable "egress_gateway_id" {}
+
+variable "subnet_tier" {}
+
+data "aws_vpc" "this" {
+  id = "${var.vpc_id}"
+}
+
+resource "aws_subnet" "public" {
+  vpc_id            = "${data.aws_vpc.this.id}"
+  cidr_block        = "${cidrsubnet(cidrsubnet(data.aws_vpc.this.cidr_block, 3, var.subnet_tier), 5, count.index)}"
+  availability_zone = "${element(split(",", var.azs), count.index)}"
+  count             = "${length(split(",", var.azs))}"
+
+  ipv6_cidr_block                 = "${cidrsubnet(cidrsubnet(data.aws_vpc.this.ipv6_cidr_block, 3, var.subnet_tier), 5, count.index)}"
+  assign_ipv6_address_on_creation = true
+
+  tags = {
+    Name    = "${var.name}.${element(split(",", var.azs), count.index)}"
+    Network = "subnet-tier-${var.subnet_tier}"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  map_public_ip_on_launch = true
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = "${data.aws_vpc.this.id}"
+  count  = "${length(split(",", var.azs))}"
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = "${var.internet_gateway_id}"
+  }
+
+  route {
+    ipv6_cidr_block = "::/0"
+    gateway_id      = "${var.internet_gateway_id}"
+  }
+
+  tags = {
+    Name = "${var.name}.${element(split(",", var.azs), count.index)}"
+  }
+}
+
+resource "aws_route_table_association" "public" {
+  count          = "${length(split(",", var.azs))}"
+  subnet_id      = aws_subnet.public[count.index].id
+  route_table_id = aws_route_table.public[count.index].id
+}
+
+output "subnet_ids" {
+  value = "${aws_subnet.public.*.id}"
+}
+
+output "tier" {
+  value      = "subnet-tier-${var.subnet_tier}"
+  depends_on = ["aws_subnet.public"]
+}
+
+output "route_table" {
+  value = "${aws_route_table.public.*.id}"
+}

--- a/aws/modules/network/subnet_tier/main.tf
+++ b/aws/modules/network/subnet_tier/main.tf
@@ -1,0 +1,19 @@
+output "public" {
+  value = "1"
+}
+
+output "private" {
+  value = "2"
+}
+
+output "management_public" {
+  value = "3"
+}
+
+output "management_private" {
+  value = "4"
+}
+
+output "private_mysql_rds" {
+  value = "5"
+}

--- a/aws/modules/network/vpc/vpc.tf
+++ b/aws/modules/network/vpc/vpc.tf
@@ -1,0 +1,57 @@
+#--------------------------------------------------------------
+# This module creates all resources necessary for a VPC
+#--------------------------------------------------------------
+
+variable "name" {
+}
+
+variable "cidr" {
+}
+
+resource "aws_vpc" "this" {
+  cidr_block           = var.cidr
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  assign_generated_ipv6_cidr_block = true
+
+  tags = {
+    Name = var.name
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_internet_gateway" "this" {
+  vpc_id = aws_vpc.this.id
+
+  tags = {
+    Name = var.name
+  }
+}
+
+resource "aws_egress_only_internet_gateway" "this" {
+  vpc_id = aws_vpc.this.id
+}
+
+output "vpc_id" {
+  value = aws_vpc.this.id
+}
+
+output "vpc_cidr" {
+  value = aws_vpc.this.cidr_block
+}
+
+output "vpc_cidr_ipv6" {
+  value = aws_vpc.this.ipv6_cidr_block
+}
+
+output "internet_gateway_id" {
+  value = aws_internet_gateway.this.id
+}
+
+output "egress_gateway_id" {
+  value = aws_egress_only_internet_gateway.this.id
+}

--- a/aws/modules/util/iam/iam.tf
+++ b/aws/modules/util/iam/iam.tf
@@ -1,0 +1,45 @@
+#--------------------------------------------------------------
+# This module is used to create an AWS IAM group and its users
+#--------------------------------------------------------------
+
+variable "name" {}
+variable "users" {}
+variable "policy" {}
+
+resource "aws_iam_group" "group" {
+  name = var.name
+}
+
+resource "aws_iam_group_policy" "policy" {
+  name   = var.name
+  group  = aws_iam_group.group.id
+  policy = var.policy
+}
+
+resource "aws_iam_user" "user" {
+  count = length(split(",", var.users))
+  name  = element(split(",", var.users), count.index)
+}
+
+resource "aws_iam_access_key" "key" {
+  count = length(split(",", var.users))
+  user  = element(aws_iam_user.user.*.name, count.index)
+}
+
+resource "aws_iam_group_membership" "membership" {
+  name  = var.name
+  group = aws_iam_group.group.name
+  users = aws_iam_user.user.*.name
+}
+
+output "users" {
+  value = join(",", aws_iam_access_key.key.*.user)
+}
+
+output "access_ids" {
+  value = join(",", aws_iam_access_key.key.*.id)
+}
+
+output "secret_keys" {
+  value = join(",", aws_iam_access_key.key.*.secret)
+}

--- a/aws/versions.tf
+++ b/aws/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = "~> 0.12"
+}

--- a/github/main.tf
+++ b/github/main.tf
@@ -1,5 +1,22 @@
-variable "github_token" {}
-variable "discord_api_secret" {}
+terraform {
+  backend "s3" {
+    bucket         = "artichoke-terraform-state"
+    region         = "us-west-2"
+    key            = "github/terraform.tfstate"
+    encrypt        = true
+    dynamodb_table = "terraform_statelock"
+
+    profile = "artichokeruby"
+  }
+}
+
+variable "github_token" {
+  type = string
+}
+
+variable "discord_api_secret" {
+  type = string
+}
 
 provider "github" {
   version = "~> 2.3"

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "scripts": {
     "fmt": "npx prettier --write '**/*'",
-    "fmt:md": "npx prettier --prose-wrap always --write '**/*.md' '*.md'"
+    "fmt:md": "npx prettier --prose-wrap always --write '**/*.md' '*.md'",
+    "fmt:tf": "terraform fmt aws && terraform fmt github && terraform fmt remote-state"
   }
 }

--- a/remote-state/README.md
+++ b/remote-state/README.md
@@ -1,0 +1,14 @@
+# Artichoke remote Terraform state
+
+The terraform configuration in this directory creates the infrastructure
+necessary to store Terraform state in S3.
+
+The state for this infra is stored in the S3 bucket created by this code.
+
+## Bootstrapping
+
+1. Comment out the `terraform` block in `main.tf`
+2. `terraform plan` and `terraform apply`
+3. Uncomment the `terraform` block
+4. `terraform init` and say yes to import
+5. `terraform plan` and `terraform apply`

--- a/remote-state/aws.tf
+++ b/remote-state/aws.tf
@@ -1,0 +1,9 @@
+variable "region" {
+  default = "us-west-2"
+}
+
+provider "aws" {
+  region  = var.region
+  version = "~> 2.17"
+  profile = "artichokeruby"
+}

--- a/remote-state/main.tf
+++ b/remote-state/main.tf
@@ -1,0 +1,59 @@
+terraform {
+  backend "s3" {
+    bucket         = "artichoke-terraform-state"
+    region         = "us-west-2"
+    key            = "remote-state/terraform.tfstate"
+    encrypt        = true
+    dynamodb_table = "terraform_statelock"
+
+    profile = "artichokeruby"
+  }
+}
+
+resource "aws_s3_bucket" "this" {
+  bucket = "artichoke-terraform-state"
+  acl    = "private"
+
+  versioning {
+    enabled = true
+  }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "aws:kms"
+      }
+    }
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  block_public_acls   = true
+  block_public_policy = true
+
+  ignore_public_acls = true
+
+  restrict_public_buckets = true
+}
+
+resource "aws_dynamodb_table" "terraform_statelock" {
+  name           = "terraform_statelock"
+  read_capacity  = 20
+  write_capacity = 20
+  hash_key       = "LockID"
+
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}

--- a/remote-state/versions.tf
+++ b/remote-state/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = "~> 0.12"
+}


### PR DESCRIPTION
This PR uses the newly created Artichoke AWS account to set up an S3
bucket for storing remote state. This PR required several steps to
bootstrap - this commit is the final state.

- Add an admin IAM group to the account that has access to all
  resources.
- Add `lopopolo` to this IAM group.
- Add a `artichoke-terraform-state` bucket and lock it down: no public
  access, server side encrypted with the default S3 KMS key.
- Add a low capacity DynamoDB table for storing terraform lock metadata.

With these steps done, add the `terraform` blocks to the `aws`,
`github`, and `remote-state` terraform bulkheads to store their state in
S3.

Fixes GH-3.
Fixes GH-4.