### PR TITLE
Upgrade to Terraform 0.13

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: "Terraform Format"
         uses: hashicorp/terraform-github-actions@master
         with:
-          tf_actions_version: 0.12.13
+          tf_actions_version: 0.13.0
           tf_actions_subcommand: "fmt"
           tf_actions_working_dir: "aws"
         env:
@@ -29,7 +29,7 @@ jobs:
       - name: "Terraform Format"
         uses: hashicorp/terraform-github-actions@master
         with:
-          tf_actions_version: 0.12.13
+          tf_actions_version: 0.13.0
           tf_actions_subcommand: "fmt"
           tf_actions_working_dir: "github"
         env:
@@ -38,7 +38,7 @@ jobs:
       - name: "Terraform Format"
         uses: hashicorp/terraform-github-actions@master
         with:
-          tf_actions_version: 0.12.13
+          tf_actions_version: 0.13.0
           tf_actions_subcommand: "fmt"
           tf_actions_working_dir: "remote-state"
         env:

--- a/aws/aws.tf
+++ b/aws/aws.tf
@@ -4,6 +4,5 @@ variable "region" {
 
 provider "aws" {
   region  = var.region
-  version = "~> 2.17"
   profile = "artichokeruby"
 }

--- a/aws/dns.tf
+++ b/aws/dns.tf
@@ -1,1 +1,1 @@
-# DNS is managed by Google Domains (registrar of Artichoke domains)
+# DNS is managed by Google Domains (registrar of Artichoke domains).

--- a/aws/email.tf
+++ b/aws/email.tf
@@ -1,1 +1,1 @@
-# email is configured using the G Suite integration in Google Domains
+# email is configured using the G Suite integration in Google Domains.

--- a/aws/versions.tf
+++ b/aws/versions.tf
@@ -1,3 +1,9 @@
 terraform {
-  required_version = "~> 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.3"
+    }
+  }
 }

--- a/github/main.tf
+++ b/github/main.tf
@@ -19,8 +19,6 @@ variable "discord_api_secret" {
 }
 
 provider "github" {
-  version = "~> 2.3"
-
   token        = var.github_token
   organization = "artichoke"
 }

--- a/github/repos.tf
+++ b/github/repos.tf
@@ -29,7 +29,7 @@ resource "github_repository" "boba" {
 
 resource "github_repository" "jasper" {
   name        = "jasper"
-  description = "🧳Single-binary packaging for Ruby applications that supports native and Wasm targets"
+  description = "🧳 Single-binary packaging for Ruby applications that supports native and Wasm targets"
 
   private = false
 

--- a/github/versions.tf
+++ b/github/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    github = {
+      source  = "hashicorp/github"
+      version = "~> 2.9"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/remote-state/aws.tf
+++ b/remote-state/aws.tf
@@ -4,6 +4,5 @@ variable "region" {
 
 provider "aws" {
   region  = var.region
-  version = "~> 2.17"
   profile = "artichokeruby"
 }

--- a/remote-state/versions.tf
+++ b/remote-state/versions.tf
@@ -1,3 +1,9 @@
 terraform {
-  required_version = "~> 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.3"
+    }
+  }
 }


### PR DESCRIPTION
- Generate provider versions
- Bump AWS provider to latest 3.x.y release (from v2.17)
- Bump GitHub provider to latest 2.9.y branch.

Changes have been applied with no diff. State is upgraded to 0.13 version.