### PR TITLE
Add GitHub team for crates.io publishers

### DIFF
--- a/.github/labels.json
+++ b/.github/labels.json
@@ -30,6 +30,11 @@
     "description": "Area: Google Domains infrastructure as code."
   },
   {
+    "name": "A-packaging",
+    "color": "f7e101",
+    "description": "Area: Packaging and publish permissions."
+  },
+  {
     "name": "A-project",
     "color": "f7e101",
     "description": "Area: Infrastructure for running an open source project."

--- a/github/main.tf
+++ b/github/main.tf
@@ -52,3 +52,14 @@ module "team_ci" {
   admins      = ["lopopolo"]
   members     = ["artichoke-ci"]
 }
+
+module "team_cratesio_publishers" {
+  source = "./modules/team"
+
+  team        = "crates.io publishers"
+  description = "Core team with perissions for publishing packages to crates.io"
+  admins      = ["lopopolo"]
+  members     = []
+
+  is_secret_team = false
+}

--- a/github/modules/team/team.tf
+++ b/github/modules/team/team.tf
@@ -14,10 +14,15 @@ variable "members" {
   type = list(string)
 }
 
+variable "is_secret_team" {
+  type    = bool
+  default = true
+}
+
 resource "github_team" "this" {
   name        = var.team
   description = var.description
-  privacy     = "secret"
+  privacy     = var.is_secret_team ? "secret" : "closed"
 }
 
 resource "github_team_membership" "admins" {


### PR DESCRIPTION
This has the potential to remove @lopopolo as a SPOF from crate
publishes.

@artichoke/crates-io-publishers has been added as an owner to the following
crates:

- artichoke - https://crates.io/crates/artichoke
- boba - https://crates.io/crates/boba
- focaccia - https://crates.io/crates/focaccia
- intaglio - https://crates.io/crates/intaglio
- rand_mt - https://crates.io/crates/rand_mt