### PR TITLE
Block WIP or unmergeable PRs

### DIFF
--- a/.github/workflows/block-merge.yaml
+++ b/.github/workflows/block-merge.yaml
@@ -4,8 +4,8 @@ name: Merge
   pull_request:
     types: [opened, labeled, unlabeled, synchronize]
 jobs:
-  blocked:
-    name: Blocked by label
+  labels:
+    name: Labels
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/block-merge.yaml
+++ b/.github/workflows/block-merge.yaml
@@ -1,0 +1,16 @@
+---
+name: Merge
+"on":
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+jobs:
+  blocked:
+    name: Blocked by label
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: mheap/github-action-required-labels@v1
+        with:
+          mode: exactly
+          count: 0
+          labels: "S-do-not-merge, S-wip"


### PR DESCRIPTION
This GitHub Action enforces that the `S-wip` and `S-do-not-merge` labels are not present on a PR. If any of the labels are present, the job in this workflow will fail.

For this job to block merges, the following must be true:

- The repo must have the `S-wip` and `S-do-not-merge` labels. These labels are standard labels added during repo scaffolding, enforced by CI.
- The `Merge / Labels` job must be required to pass before merging using a branch protection rule.

This GitHub Action replicates a piece of CI I like from work: when a PR or branch is marked WIP or "do not merge", the GitHub web interface should block merges.

This makes the decision to not merge less arbitrary than "@lopopolo won't push the merge button" and allows signaling if a PR is not ready even without a "changes requested" PR review.

https://twitter.com/artichokeruby/status/1303049221004689408