### PR TITLE
Import all GitHub repositories into Terraform config

### DIFF
--- a/github/.terraform.lock.hcl
+++ b/github/.terraform.lock.hcl
@@ -2,19 +2,20 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/github" {
-  version     = "4.1.0"
+  version     = "4.5.1"
   constraints = "~> 4.1"
   hashes = [
-    "h1:nOqwWaZWGnOchhT8DWGrOD1cW6/ylxfhPNwx3QxlERQ=",
-    "zh:12a12ef18103cb942ae185c2faaa51973f9f55adf480254866169de0c1a2f870",
-    "zh:4f90da2eeed0182b68cd47b76f110eb35b5f0ce0ea2bdfde60cbdbad350910c6",
-    "zh:509f584e57e7960cd128e0b77eeefd8968e0e5f3dbc6f86f031f007720e817fc",
-    "zh:63c2b58b66ea7868fba323a4899a82bcdf43a3a4c7b2fdd2e241d94aebda996e",
-    "zh:7e7b72d1378acb21fdf116703ff865ebabe9fc014da89f93dfb3c505d5d0907f",
-    "zh:8b74873ce8eeaed0bd7e37c4bd0a826e25404ffc5b9f7126e923dee3596d8634",
-    "zh:8bf2aeaee8744f0140d5bfb850e958d0484b3657878e7d5f9e798ec2125300bd",
-    "zh:cedb3020864da3ec7d34d170747b682fd7e3b1a9f37518a871e4b6a60d4411e2",
-    "zh:d4b34183739236a22e38ce1e662495c9dbeb4f2065a607b6209e8427a30ca571",
-    "zh:e5a24e07208a0adc37bb54c510224a2dc56aa14adb7bb86da433ef86b4f6d0b3",
+    "h1:G6KH65xHzqNmcVLpq8BuNp/C7WKNiPBghp4va8AKBto=",
+    "zh:273a7e12cd59005e14eb214c488da3bb3c938b169ce94d20de42897f79f9b0cf",
+    "zh:38cb6df63750fe0e490c7d581d90c1ea8a7e8f3e0dbc191232ac2f58971000a9",
+    "zh:3ac5c60f24bdfc975def2ee12e7cfae94306de027549701e8608b58d17b879ec",
+    "zh:55a527889b94c817003fef54338c7e5aec6d44f0dc5e568aad616f8f3ce555ba",
+    "zh:565bba6b5fb0a7ad0c75136c21ad223d7c4c3430843268da426a3ba4a1907a89",
+    "zh:5feb9dfaab30d43fd323f6472ea9572e710f0f0626c68acab3dd244a3a0928db",
+    "zh:75e3e549cdb10aec1b9681410c902ca1e5ec047b6754b0520d614f4e07f0bf1f",
+    "zh:7d0b0d853476e2820c829658023325d0b1b72bf0d1132dd2f8507bf7c4af035e",
+    "zh:81b15a0e67f3e973e4c0c3ee3eeee7e7a945ba2a891f8c5d4302709f14884a84",
+    "zh:b53a1c63f6bc4a3873d6f1802b9e3c7837aa137688f0ae3bf8d3a5851a626105",
+    "zh:f174e95c2407dc36c9617af8a19e6436edaaf0ad0c57d2d9d8284b1e37c0bf66",
   ]
 }

--- a/github/archived-repos.tf
+++ b/github/archived-repos.tf
@@ -1,6 +1,6 @@
 resource "github_repository" "artichoke_ci" {
-  name         = "artichoke-ci"
-  description  = "🏗 CI infrastructure and images for Artichoke"
+  name        = "artichoke-ci"
+  description = "🏗 CI infrastructure and images for Artichoke"
 
   archived   = true
   visibility = "public"

--- a/github/archived-repos.tf
+++ b/github/archived-repos.tf
@@ -1,0 +1,143 @@
+resource "github_repository" "artichoke_ci" {
+  name         = "artichoke-ci"
+  description  = "🏗 Archived CI infrastructure and images for Artichoke, migrated to GitHub Actions"
+  homepage_url = "https://github.com/artichoke/artichoke/tree/trunk/.github/workflows"
+
+  archived   = true
+  visibility = "public"
+
+  has_downloads = false
+  has_issues    = true
+  has_projects  = false
+  has_wiki      = false
+
+  delete_branch_on_merge = true
+
+  topics = [
+    "artichoke",
+    "base-image",
+    "build",
+    "ci",
+    "circleci",
+    "docker",
+    "dockerfile",
+  ]
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "github_repository" "cactusref" {
+  name         = "cactusref"
+  description  = "🌵 Archived experimental cycle-aware reference counting crate"
+  homepage_url = "https://artichoke.github.io/cactusref/cactusref/"
+
+  archived   = true
+  visibility = "public"
+
+  has_downloads = false
+  has_issues    = true
+  has_projects  = false
+  has_wiki      = false
+
+  delete_branch_on_merge = true
+
+  topics = [
+    "artichoke",
+    "garbage-collection",
+    "garbage-collector",
+    "gc",
+    "memory-management",
+    "reference-counting",
+    "rust",
+    "rust-crate",
+    "smart-pointer",
+  ]
+
+  pages {
+    source {
+      branch = "gh-pages"
+      path   = "/"
+    }
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "github_repository" "ferrocarril" {
+  name         = "ferrocarril"
+  description  = "🚆 Archived experiments to embed Ruby on Rails in Rust with mruby, migrated to artichoke/artichoke repository"
+  homepage_url = "https://www.artichokeruby.org/"
+
+  visibility = "public"
+
+  has_downloads = true
+  has_issues    = true
+  has_projects  = false
+  has_wiki      = false
+
+  delete_branch_on_merge = true
+
+  topics = [
+    "artichoke",
+    "language",
+    "programming-language",
+    "ruby",
+    "ruby-language",
+    "rust",
+    "rust-application",
+    "rust-crate",
+  ]
+
+  pages {
+    source {
+      branch = "gh-pages"
+      path   = "/"
+    }
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "github_repository" "rust_mersenne_twister" {
+  name         = "rust-mersenne-twister"
+  description  = "Archived fork of mersenne-twister crate, migrated to artichoke/rand_mt repository"
+  homepage_url = "https://github.com/artichoke/rand_mt"
+
+  archived   = true
+  visibility = "public"
+
+  has_downloads = false
+  has_issues    = false
+  has_projects  = false
+  has_wiki      = false
+
+  delete_branch_on_merge = true
+
+  topics = [
+    "archived",
+    "artichoke",
+    "mersenne-twister",
+    "rand",
+    "random",
+    "rng",
+    "rust",
+    "rust-crate",
+  ]
+
+  pages {
+    source {
+      branch = "gh-pages"
+      path   = "/"
+    }
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}

--- a/github/archived-repos.tf
+++ b/github/archived-repos.tf
@@ -1,17 +1,16 @@
 resource "github_repository" "artichoke_ci" {
   name         = "artichoke-ci"
-  description  = "🏗 Archived CI infrastructure and images for Artichoke, migrated to GitHub Actions"
-  homepage_url = "https://github.com/artichoke/artichoke/tree/trunk/.github/workflows"
+  description  = "🏗 CI infrastructure and images for Artichoke"
 
   archived   = true
   visibility = "public"
 
-  has_downloads = false
+  has_downloads = true
   has_issues    = true
   has_projects  = false
-  has_wiki      = false
+  has_wiki      = true
 
-  delete_branch_on_merge = true
+  delete_branch_on_merge = false
 
   topics = [
     "artichoke",
@@ -30,16 +29,16 @@ resource "github_repository" "artichoke_ci" {
 
 resource "github_repository" "cactusref" {
   name         = "cactusref"
-  description  = "🌵 Archived experimental cycle-aware reference counting crate"
+  description  = "🌵 Cycle-Aware Reference Counting in Rust"
   homepage_url = "https://artichoke.github.io/cactusref/cactusref/"
 
   archived   = true
   visibility = "public"
 
-  has_downloads = false
+  has_downloads = true
   has_issues    = true
   has_projects  = false
-  has_wiki      = false
+  has_wiki      = true
 
   delete_branch_on_merge = true
 
@@ -47,12 +46,10 @@ resource "github_repository" "cactusref" {
     "artichoke",
     "garbage-collection",
     "garbage-collector",
-    "gc",
     "memory-management",
     "reference-counting",
     "rust",
     "rust-crate",
-    "smart-pointer",
   ]
 
   pages {
@@ -69,27 +66,26 @@ resource "github_repository" "cactusref" {
 
 resource "github_repository" "ferrocarril" {
   name         = "ferrocarril"
-  description  = "🚆 Archived experiments to embed Ruby on Rails in Rust with mruby, migrated to artichoke/artichoke repository"
-  homepage_url = "https://www.artichokeruby.org/"
+  description  = "🚆 Experiments to embed Ruby on Rails in Rust with mruby"
+  homepage_url = "https://artichoke.github.io/ferrocarril/mruby/"
 
+  archived   = true
   visibility = "public"
 
   has_downloads = true
   has_issues    = true
   has_projects  = false
-  has_wiki      = false
+  has_wiki      = true
 
-  delete_branch_on_merge = true
+  delete_branch_on_merge = false
 
   topics = [
     "artichoke",
-    "language",
-    "programming-language",
+    "rack",
     "ruby",
-    "ruby-language",
     "rust",
-    "rust-application",
-    "rust-crate",
+    "sinatra",
+    "unicorn",
   ]
 
   pages {
@@ -106,29 +102,20 @@ resource "github_repository" "ferrocarril" {
 
 resource "github_repository" "rust_mersenne_twister" {
   name         = "rust-mersenne-twister"
-  description  = "Archived fork of mersenne-twister crate, migrated to artichoke/rand_mt repository"
+  description  = "Fork migrated to artichoke/rand_mt"
   homepage_url = "https://github.com/artichoke/rand_mt"
 
   archived   = true
   visibility = "public"
 
-  has_downloads = false
+  has_downloads = true
   has_issues    = false
   has_projects  = false
-  has_wiki      = false
+  has_wiki      = true
 
   delete_branch_on_merge = true
 
-  topics = [
-    "archived",
-    "artichoke",
-    "mersenne-twister",
-    "rand",
-    "random",
-    "rng",
-    "rust",
-    "rust-crate",
-  ]
+  topics = []
 
   pages {
     source {

--- a/github/crate-reservation-repos.tf
+++ b/github/crate-reservation-repos.tf
@@ -1,0 +1,37 @@
+locals {
+  crate_reservations = {
+    artichoke      = "artichoke-reserve"
+    artichokeruby  = "artichokeruby-reserve"
+    artichoke-ruby = "artichoke-ruby-reserve"
+    boba           = "boba-reserve"
+    invokedynamic  = "invokedynamic-reserve"
+  }
+}
+
+resource "github_repository" "private_crate_reservation" {
+  for_each = local.crate_reservations
+
+  name         = each.value
+  description  = format("📦 This repo was used to reserve the %s crate on crates.io", each.key)
+  homepage_url = format("https://crates.io/crates/%s", each.key)
+
+  visibility = "private"
+
+  has_downloads = false
+  has_issues    = false
+  has_projects  = false
+  has_wiki      = false
+
+  delete_branch_on_merge = true
+
+  topics = [
+    "artichoke",
+    "reserve",
+    "rust",
+    "rust-crate",
+  ]
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}

--- a/github/forked-repos.tf
+++ b/github/forked-repos.tf
@@ -1,6 +1,6 @@
 resource "github_repository" "mruby" {
-  name         = "mruby"
-  description  = "Artichoke fork of mruby 2.x, a Lightweight Ruby"
+  name        = "mruby"
+  description = "Artichoke fork of mruby 2.x, a Lightweight Ruby"
 
   visibility = "public"
 
@@ -66,8 +66,8 @@ resource "github_branch_default" "mspec" {
 }
 
 resource "github_repository" "onigmo" {
-  name         = "Onigmo"
-  description  = "Artichoke fork of Onigmo, a regular expressions library forked from Oniguruma."
+  name        = "Onigmo"
+  description = "Artichoke fork of Onigmo, a regular expressions library forked from Oniguruma."
 
   visibility = "public"
 
@@ -94,8 +94,8 @@ resource "github_repository" "onigmo" {
 }
 
 resource "github_repository" "oniguruma" {
-  name         = "oniguruma"
-  description  = "Artichoke fork of oniguruma, a regular expression library"
+  name        = "oniguruma"
+  description = "Artichoke fork of oniguruma, a regular expression library"
 
   visibility = "public"
 
@@ -192,8 +192,8 @@ resource "github_branch_default" "rust_onig" {
 }
 
 resource "github_repository" "spec" {
-  name         = "spec"
-  description  = "Artichoke fork of the Ruby Spec Suite aka ruby/spec"
+  name        = "spec"
+  description = "Artichoke fork of the Ruby Spec Suite aka ruby/spec"
 
   visibility = "public"
 

--- a/github/forked-repos.tf
+++ b/github/forked-repos.tf
@@ -1,0 +1,225 @@
+resource "github_repository" "mruby" {
+  name         = "mruby"
+  description  = "Artichoke fork of mruby 2.x, a Lightweight Ruby"
+
+  visibility = "public"
+
+  has_downloads = false
+  has_issues    = false
+  has_projects  = false
+  has_wiki      = false
+
+  delete_branch_on_merge = true
+  vulnerability_alerts   = false
+
+  topics = [
+    "artichoke",
+    "embedded",
+    "fork",
+    "mruby",
+    "ruby",
+    "vendor"
+  ]
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "github_branch_default" "mruby" {
+  repository = github_repository.mruby.name
+  branch     = "artichoke-vendor"
+}
+
+resource "github_repository" "mspec" {
+  name         = "mspec"
+  description  = "Artichoke fork of MSpec, an RSpec-like test runner for the Ruby Spec Suite"
+  homepage_url = "https://github.com/ruby/spec"
+
+  visibility = "public"
+
+  has_downloads = false
+  has_issues    = false
+  has_projects  = false
+  has_wiki      = false
+
+  delete_branch_on_merge = true
+  vulnerability_alerts   = false
+
+  topics = [
+    "artichoke",
+    "embedded",
+    "fork",
+    "ruby",
+    "spec",
+    "vendor",
+  ]
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "github_branch_default" "mspec" {
+  repository = github_repository.mspec.name
+  branch     = "artichoke-vendor"
+}
+
+resource "github_repository" "onigmo" {
+  name         = "Onigmo"
+  description  = "Artichoke fork of Onigmo, a regular expressions library forked from Oniguruma."
+
+  visibility = "public"
+
+  has_downloads = false
+  has_issues    = false
+  has_projects  = false
+  has_wiki      = false
+
+  delete_branch_on_merge = true
+  vulnerability_alerts   = false
+
+  topics = [
+    "artichoke",
+    "c",
+    "fork",
+    "regex",
+    "regexp",
+    "ruby",
+  ]
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "github_repository" "oniguruma" {
+  name         = "oniguruma"
+  description  = "Artichoke fork of oniguruma, a regular expression library"
+
+  visibility = "public"
+
+  has_downloads = false
+  has_issues    = false
+  has_projects  = false
+  has_wiki      = false
+
+  delete_branch_on_merge = true
+  vulnerability_alerts   = false
+
+  topics = [
+    "artichoke",
+    "c",
+    "fork",
+    "regex",
+    "regexp",
+    "ruby",
+  ]
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "github_repository" "ruby" {
+  name         = "ruby"
+  description  = "Artichoke fork of Ruby 2.6.3"
+  homepage_url = "https://www.ruby-lang.org/"
+
+  visibility = "public"
+
+  has_downloads = false
+  has_issues    = false
+  has_projects  = false
+  has_wiki      = false
+
+  delete_branch_on_merge = true
+  vulnerability_alerts   = false
+
+  topics = [
+    "artichoke",
+    "c",
+    "embedded",
+    "fork",
+    "ruby",
+    "vendor",
+  ]
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "github_branch_default" "ruby" {
+  repository = github_repository.ruby.name
+  branch     = "artichoke-vendor"
+}
+
+
+resource "github_repository" "rust_onig" {
+  name         = "rust-onig"
+  description  = "Artichoke fork of rust-onig, Rust bindings for the Oniguruma regex library"
+  homepage_url = "https://docs.rs/crate/onig/"
+
+  visibility = "public"
+
+  has_downloads = false
+  has_issues    = false
+  has_projects  = false
+  has_wiki      = false
+
+  delete_branch_on_merge = true
+  vulnerability_alerts   = false
+
+  topics = [
+    "artichoke",
+    "fork",
+    "regex",
+    "regexp",
+    "ruby",
+    "rust",
+    "rust-crate",
+  ]
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "github_branch_default" "rust_onig" {
+  repository = github_repository.rust_onig.name
+  branch     = "artichoke-vendor"
+}
+
+resource "github_repository" "spec" {
+  name         = "spec"
+  description  = "Artichoke fork of the Ruby Spec Suite aka ruby/spec"
+
+  visibility = "public"
+
+  has_downloads = false
+  has_issues    = false
+  has_projects  = false
+  has_wiki      = false
+
+  delete_branch_on_merge = true
+  vulnerability_alerts   = false
+
+  topics = [
+    "artichoke",
+    "embedded",
+    "fork",
+    "ruby",
+    "spec",
+    "vendor",
+  ]
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "github_branch_default" "spec" {
+  repository = github_repository.spec.name
+  branch     = "artichoke-vendor"
+}

--- a/github/main.tf
+++ b/github/main.tf
@@ -51,8 +51,14 @@ module "team_ci" {
 
   team        = "ci"
   description = "Builds"
-  admins      = ["lopopolo"]
-  members     = ["artichoke-ci"]
+
+  admins = {
+    lopopolo = "lopopolo"
+  }
+
+  members = {
+    artichoke-ci = "artichoke-ci"
+  }
 }
 
 module "team_cratesio_publishers" {
@@ -60,8 +66,12 @@ module "team_cratesio_publishers" {
 
   team        = "crates.io publishers"
   description = "Core team with perissions for publishing packages to crates.io"
-  admins      = ["lopopolo"]
-  members     = []
+
+  admins = {
+    lopopolo = "lopopolo"
+  }
+
+  members = {}
 
   is_secret_team = false
 }

--- a/github/modules/team/team.tf
+++ b/github/modules/team/team.tf
@@ -7,11 +7,11 @@ variable "description" {
 }
 
 variable "admins" {
-  type = list(string)
+  type = map
 }
 
 variable "members" {
-  type = list(string)
+  type = map
 }
 
 variable "is_secret_team" {
@@ -26,15 +26,17 @@ resource "github_team" "this" {
 }
 
 resource "github_team_membership" "admins" {
-  count    = length(var.admins)
+  for_each = var.admins
+
   team_id  = github_team.this.id
-  username = element(var.admins, count.index)
+  username = each.value
   role     = "maintainer"
 }
 
 resource "github_team_membership" "members" {
-  count    = length(var.members)
+  for_each = var.members
+
   team_id  = github_team.this.id
-  username = element(var.members, count.index)
+  username = each.value
   role     = "member"
 }

--- a/github/repos.tf
+++ b/github/repos.tf
@@ -22,6 +22,8 @@ resource "github_repository" "artichoke" {
     "rust",
     "rust-application",
     "rust-crate",
+    "wasm",
+    "webassembly",
   ]
 
   pages {

--- a/github/repos.tf
+++ b/github/repos.tf
@@ -1,3 +1,75 @@
+resource "github_repository" "artichoke" {
+  name         = "artichoke"
+  description  = "💎 Artichoke is a Ruby made with Rust"
+  homepage_url = "https://www.artichokeruby.org/"
+
+  visibility = "public"
+
+  has_downloads = true
+  has_issues    = true
+  has_projects  = false
+  has_wiki      = false
+
+  delete_branch_on_merge = true
+  vulnerability_alerts   = true
+
+  topics = [
+    "artichoke",
+    "language",
+    "programming-language",
+    "ruby",
+    "ruby-language",
+    "rust",
+    "rust-application",
+    "rust-crate",
+  ]
+
+  pages {
+    source {
+      branch = "gh-pages"
+      path   = "/"
+    }
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "github_repository" "artichoke_github_io" {
+  name         = "artichoke.github.io"
+  description  = "⏭ Redirect to Artichoke project website"
+  homepage_url = "https://artichoke.github.io/"
+
+  visibility = "public"
+
+  has_downloads = true
+  has_issues    = true
+  has_projects  = false
+  has_wiki      = false
+
+  delete_branch_on_merge = true
+  vulnerability_alerts   = true
+
+  topics = [
+    "artichoke",
+    "gh-pages",
+    "project-website",
+    "static-site",
+  ]
+
+  pages {
+    source {
+      branch = "gh-pages"
+      path   = "/"
+    }
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
 resource "github_repository" "boba" {
   name         = "boba"
   description  = "💦 Rust implementation of the Bubble Babble binary data encoding"
@@ -8,19 +80,167 @@ resource "github_repository" "boba" {
   has_downloads = true
   has_issues    = true
   has_projects  = false
-  has_wiki      = true
+  has_wiki      = false
 
   delete_branch_on_merge = true
+  vulnerability_alerts   = true
 
   topics = [
     "artichoke",
     "bubblebabble",
-    "encoding",
     "decoding",
+    "encoding",
     "ruby",
     "rust",
     "rust-crate",
   ]
+
+  pages {
+    source {
+      branch = "gh-pages"
+      path   = "/"
+    }
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "github_repository" "clang_format" {
+  name         = "clang-format"
+  description  = "✏️ clang-format runner for CI"
+  homepage_url = "https://github.com/artichoke/clang-format#readme"
+
+  visibility = "public"
+
+  has_downloads = true
+  has_issues    = true
+  has_projects  = false
+  has_wiki      = false
+
+  delete_branch_on_merge = true
+  vulnerability_alerts   = true
+
+  topics = [
+    "artichoke",
+    "c",
+    "ci",
+    "clang-format",
+    "formatter",
+    "javascript",
+    "linter",
+    "nodejs",
+    "npx",
+  ]
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "github_repository" "docker_artichoke_nightly" {
+  name         = "docker-artichoke-nightly"
+  description  = "🐳 Docker builds for nightly Artichoke"
+  homepage_url = "https://hub.docker.com/r/artichokeruby/artichoke"
+
+  visibility = "public"
+
+  has_downloads = true
+  has_issues    = true
+  has_projects  = false
+  has_wiki      = false
+
+  delete_branch_on_merge = true
+  vulnerability_alerts   = true
+
+  topics = [
+    "artichoke",
+    "docker",
+    "nightly",
+    "nightly-build",
+    "ruby",
+    "rust",
+    "rust-application",
+  ]
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "github_repository" "focaccia" {
+  name         = "focaccia"
+  description  = "🍞 no_std Unicode case folding comparisons"
+  homepage_url = "https://crates.io/crates/focaccia"
+
+  visibility = "public"
+
+  has_downloads = true
+  has_issues    = true
+  has_projects  = false
+  has_wiki      = false
+
+  delete_branch_on_merge = true
+  vulnerability_alerts   = true
+
+  topics = [
+    "artichoke",
+    "case",
+    "case-folding",
+    "no-std",
+    "rust",
+    "rust-crate",
+    "unicode",
+    "unicode-case-folding",
+    "utf-8"
+  ]
+
+  pages {
+    source {
+      branch = "gh-pages"
+      path   = "/"
+    }
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "github_repository" "intaglio" {
+  name         = "intaglio"
+  description  = "🗃 UTF-8 string and bytestring interner"
+  homepage_url = "https://crates.io/crates/intaglio"
+
+  visibility = "public"
+
+  has_downloads = true
+  has_issues    = true
+  has_projects  = false
+  has_wiki      = false
+
+  delete_branch_on_merge = true
+  vulnerability_alerts   = true
+
+  topics = [
+    "artichoke",
+    "bytes",
+    "interner",
+    "rust",
+    "rust-crate",
+    "string-interning",
+    "symbol",
+    "symbol-table",
+    "utf-8",
+  ]
+
+  pages {
+    source {
+      branch = "gh-pages"
+      path   = "/"
+    }
+  }
 
   lifecycle {
     prevent_destroy = true
@@ -36,18 +256,124 @@ resource "github_repository" "jasper" {
   has_downloads = true
   has_issues    = true
   has_projects  = false
-  has_wiki      = true
+  has_wiki      = false
 
   delete_branch_on_merge = true
+  vulnerability_alerts   = true
 
   topics = [
     "artichoke",
     "bundler",
     "packaging",
     "ruby",
+    "rust",
+    "rust-application",
     "wasm",
     "webassembly",
   ]
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "github_repository" "logo" {
+  name         = "logo"
+  description  = "🖼 Project logos for Artichoke Ruby"
+  homepage_url = "https://www.npmjs.com/package/@artichokeruby/logo"
+
+  visibility = "public"
+
+  has_downloads = true
+  has_issues    = true
+  has_projects  = false
+  has_wiki      = false
+
+  delete_branch_on_merge = true
+  vulnerability_alerts   = true
+
+  topics = [
+    "artichoke",
+    "branding",
+    "javascript",
+    "logo",
+    "static-assets",
+  ]
+
+  pages {
+    source {
+      branch = "gh-pages"
+      path   = "/"
+    }
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "github_repository" "nightly" {
+  name         = "nightly"
+  description  = "🌌 Nightly builds of Artichoke Ruby"
+  homepage_url = "https://github.com/artichoke/nightly/releases/latest"
+
+  visibility = "public"
+
+  has_downloads = true
+  has_issues    = true
+  has_projects  = false
+  has_wiki      = false
+
+  delete_branch_on_merge = true
+  vulnerability_alerts   = true
+
+  topics = [
+    "artichoke",
+    "nightly",
+    "nightly-build",
+    "ruby",
+    "rust",
+    "rust-application",
+  ]
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "github_repository" "playground" {
+  name         = "playground"
+  description  = "🎡 Artichoke Ruby Wasm Playground"
+  homepage_url = "https://artichoke.run/"
+
+  visibility = "public"
+
+  has_downloads = true
+  has_issues    = true
+  has_projects  = false
+  has_wiki      = false
+
+  delete_branch_on_merge = true
+  vulnerability_alerts   = true
+
+  topics = [
+    "artichoke",
+    "playground",
+    "programming-language",
+    "ruby",
+    "rust",
+    "rust-application",
+    "wasm",
+    "webassembly",
+  ]
+
+  pages {
+    cname = "artichoke.run"
+    source {
+      branch = "gh-pages"
+      path   = "/"
+    }
+  }
 
   lifecycle {
     prevent_destroy = true
@@ -63,9 +389,10 @@ resource "github_repository" "project_infrastructure" {
   has_downloads = true
   has_issues    = true
   has_projects  = false
-  has_wiki      = true
+  has_wiki      = false
 
   delete_branch_on_merge = true
+  vulnerability_alerts   = true
 
   topics = [
     "artichoke",
@@ -73,6 +400,239 @@ resource "github_repository" "project_infrastructure" {
     "meta",
     "terraform",
   ]
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "github_repository" "rand_mt" {
+  name         = "rand_mt"
+  description  = "🌪 Mersenne Twister implementation backed by rand_core"
+  homepage_url = "https://crates.io/crates/rand_mt"
+
+  visibility = "public"
+
+  has_downloads = true
+  has_issues    = true
+  has_projects  = false
+  has_wiki      = false
+
+  delete_branch_on_merge = true
+  vulnerability_alerts   = true
+
+  topics = [
+    "artichoke",
+    "mersenne-twister",
+    "no-std",
+    "rand",
+    "random",
+    "rng",
+    "rust",
+    "rust-crate",
+  ]
+
+  pages {
+    source {
+      branch = "gh-pages"
+      path   = "/"
+    }
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "github_repository" "roe" {
+  name         = "roe"
+  description  = "🍣 Unicode case converters"
+  homepage_url = "https://crates.io/crates/roe"
+
+  visibility = "public"
+
+  has_downloads = true
+  has_issues    = true
+  has_projects  = false
+  has_wiki      = false
+
+  delete_branch_on_merge = true
+  vulnerability_alerts   = true
+
+  topics = [
+    "artichoke",
+    "case",
+    "case-mapping",
+    "lowercase",
+    "no-std",
+    "rust",
+    "rust-crate",
+    "titlecase",
+    "unicode",
+    "unicode-case-mapping",
+    "uppercase",
+    "utf-8"
+  ]
+
+  pages {
+    source {
+      branch = "gh-pages"
+      path   = "/"
+    }
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "github_repository" "rubyconf" {
+  name         = "rubyconf"
+  description  = "📽 RubyConf presentations"
+  homepage_url = "https://artichoke.github.io/rubyconf/"
+
+  visibility = "public"
+
+  has_downloads = true
+  has_issues    = true
+  has_projects  = false
+  has_wiki      = false
+
+  delete_branch_on_merge = true
+  vulnerability_alerts   = true
+
+  topics = [
+    "artichoke",
+    "conference-talk",
+    "deck",
+    "gh-pages",
+    "presentation",
+    "ruby",
+    "rubyconf",
+    "slideshow",
+    "static-site",
+    "wasm",
+    "webassembly",
+  ]
+
+  pages {
+    source {
+      branch = "gh-pages"
+      path   = "/"
+    }
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "github_repository" "rubyconf2019_artichoke_run" {
+  name         = "rubyconf2019.artichoke.run"
+  description  = "📸 A snapshot of artichoke.run that runs the playground as of RubyConf 2019"
+  homepage_url = "https://rubyconf2019.artichoke.run/"
+
+  visibility = "public"
+
+  has_downloads = true
+  has_issues    = true
+  has_projects  = false
+  has_wiki      = false
+
+  delete_branch_on_merge = true
+  vulnerability_alerts   = true
+
+  topics = [
+    "artichoke",
+    "playground",
+    "programming-language",
+    "ruby",
+    "rust",
+    "rust-application",
+    "snapshot",
+    "wasm",
+    "webassembly",
+  ]
+
+  pages {
+    cname = "rubyconf2019.artichoke.run"
+    source {
+      branch = "gh-pages"
+      path   = "/"
+    }
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "github_repository" "strudel" {
+  name         = "strudel"
+  description  = "🥐 🥮 Rust port and drop-in replacement for the `st_hash` C hash table library"
+  homepage_url = "https://artichoke.github.io/strudel/strudel/"
+
+  visibility = "public"
+
+  has_downloads = true
+  has_issues    = true
+  has_projects  = false
+  has_wiki      = false
+
+  delete_branch_on_merge = true
+  vulnerability_alerts   = true
+
+  topics = [
+    "artichoke",
+    "c",
+    "ffi",
+    "hashmap",
+    "ruby",
+    "rust",
+    "rust-crate",
+  ]
+
+  pages {
+    source {
+      branch = "gh-pages"
+      path   = "/"
+    }
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "github_repository" "www_artichokeruby_org" {
+  name         = "www.artichokeruby.org"
+  description  = "🌐 Artichoke Ruby project website"
+  homepage_url = "https://www.artichokeruby.org/"
+
+  visibility = "public"
+
+  has_downloads = true
+  has_issues    = true
+  has_projects  = false
+  has_wiki      = false
+
+  delete_branch_on_merge = true
+  vulnerability_alerts   = true
+
+  topics = [
+    "artichoke",
+    "gh-pages",
+    "project-website",
+    "static-site",
+  ]
+
+  pages {
+    cname = "www.artichokeruby.org"
+    source {
+      branch = "gh-pages"
+      path   = "/"
+    }
+  }
 
   lifecycle {
     prevent_destroy = true

--- a/github/users.tf
+++ b/github/users.tf
@@ -1,9 +1,23 @@
-resource "github_membership" "membership_lopopolo" {
-  username = "lopopolo"
+locals {
+  admins = {
+    lopopolo = "lopopolo"
+  }
+
+  members = {
+    artichoke-ci = "artichoke-ci"
+  }
+}
+
+resource "github_membership" "admins" {
+  for_each = local.admins
+
+  username = each.value
   role     = "admin"
 }
 
-resource "github_membership" "membership_artichoke_ci" {
-  username = "artichoke-ci"
+resource "github_membership" "members" {
+  for_each = local.members
+
+  username = each.value
   role     = "member"
 }


### PR DESCRIPTION
Update topics on some repos, disable wikis, rename descriptions of forks to indicate they are forks.

Set `artichoke-vendor` default branches on forks that use this pattern.

Enable creation and maintenance of crate reservation repos with a `for_each` resource.

Switch team configuration to a map and `for_each` resource-based configuration.

This PR updates the lockfile to pull in the latest GitHub provider.

These changes are already applied.

Closes #20.
Closes #21.
Closes #22.
Closes #24.