### PR TITLE
The GitHub provider has moved

### DIFF
--- a/github/.terraform.lock.hcl
+++ b/github/.terraform.lock.hcl
@@ -2,6 +2,24 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/github" {
+  version = "4.5.1"
+  hashes = [
+    "h1:G6KH65xHzqNmcVLpq8BuNp/C7WKNiPBghp4va8AKBto=",
+    "zh:273a7e12cd59005e14eb214c488da3bb3c938b169ce94d20de42897f79f9b0cf",
+    "zh:38cb6df63750fe0e490c7d581d90c1ea8a7e8f3e0dbc191232ac2f58971000a9",
+    "zh:3ac5c60f24bdfc975def2ee12e7cfae94306de027549701e8608b58d17b879ec",
+    "zh:55a527889b94c817003fef54338c7e5aec6d44f0dc5e568aad616f8f3ce555ba",
+    "zh:565bba6b5fb0a7ad0c75136c21ad223d7c4c3430843268da426a3ba4a1907a89",
+    "zh:5feb9dfaab30d43fd323f6472ea9572e710f0f0626c68acab3dd244a3a0928db",
+    "zh:75e3e549cdb10aec1b9681410c902ca1e5ec047b6754b0520d614f4e07f0bf1f",
+    "zh:7d0b0d853476e2820c829658023325d0b1b72bf0d1132dd2f8507bf7c4af035e",
+    "zh:81b15a0e67f3e973e4c0c3ee3eeee7e7a945ba2a891f8c5d4302709f14884a84",
+    "zh:b53a1c63f6bc4a3873d6f1802b9e3c7837aa137688f0ae3bf8d3a5851a626105",
+    "zh:f174e95c2407dc36c9617af8a19e6436edaaf0ad0c57d2d9d8284b1e37c0bf66",
+  ]
+}
+
+provider "registry.terraform.io/integrations/github" {
   version     = "4.5.1"
   constraints = "~> 4.1"
   hashes = [

--- a/github/versions.tf
+++ b/github/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     github = {
-      source  = "hashicorp/github"
+      source  = "integrations/github"
       version = "~> 4.1"
     }
   }


### PR DESCRIPTION
Update `required_providers`.