### PR TITLE
Refactor AWS access key outputs to use a map structure

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -43,9 +43,9 @@ task fmt: %i[fmt:terraform fmt:text]
 namespace :fmt do
   desc 'Format Terraform sources with terraform fmt'
   task :terraform do
-    sh 'terraform -chdir aws fmt'
-    sh 'terraform -chdir github fmt'
-    sh 'terraform -chdir remote-state fmt'
+    sh 'terraform -chdir=aws fmt'
+    sh 'terraform -chdir=github fmt'
+    sh 'terraform -chdir=remote-state fmt'
   end
 
   desc 'Format text, YAML, and Markdown sources with prettier'

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -27,7 +27,7 @@ variable "github_actions_runners" {
   type = map(string)
 
   default = {
-    github-actions-repo-project-infrastructure = "github-actions-repo-project-infrastructure"
+    project-infrastructure = "github-actions-repo-project-infrastructure"
   }
 }
 
@@ -88,36 +88,32 @@ output "config" {
   value = <<CONFIG
 
 Admin IAM:
-  Admin Users: ${join(
-  "\n               ",
-  formatlist("%s", module.iam_admin.users),
-  )}
-
-  Access IDs: ${join(
-  "\n              ",
-  formatlist("%s", module.iam_admin.access_ids),
-  )}
-
-  Secret Keys: ${join(
-  "\n               ",
-  formatlist("%s", module.iam_admin.secret_keys),
-  )}
+${join(
+  "\n\n",
+  formatlist(
+    "%s",
+    [for user in keys(module.iam_admin.users) :
+      join("\n", [
+        "  user: ${module.iam_admin.users[user]}",
+        "    access id: ${module.iam_admin.access_ids[user]}",
+        "    secret key: ${module.iam_admin.secret_keys[user]}"
+      ])
+    ]
+  ))}
 
 GitHub Actions IAM:
-  Admin Users: ${join(
-  "\n               ",
-  formatlist("%s", module.github_actions_runner_read_only.users),
-  )}
-
-  Access IDs: ${join(
-  "\n              ",
-  formatlist("%s", module.github_actions_runner_read_only.access_ids),
-  )}
-
-  Secret Keys: ${join(
-  "\n               ",
-  formatlist("%s", module.github_actions_runner_read_only.secret_keys),
-)}
+${join(
+  "\n\n",
+  formatlist(
+    "%s",
+    [for user in keys(module.github_actions_runner_read_only.users) :
+      join("\n", [
+        "  user: ${module.github_actions_runner_read_only.users[user]}",
+        "    access id: ${module.github_actions_runner_read_only.access_ids[user]}",
+        "    secret key: ${module.github_actions_runner_read_only.secret_keys[user]}"
+      ])
+    ]
+))}
 
 CONFIG
 
@@ -135,10 +131,10 @@ output "iam_admin_secret_keys" {
   value = module.iam_admin.secret_keys
 }
 
-output "github_actions_iam_access_id" {
-  value = module.github_actions_runner_read_only.access_ids[0]
+output "github_actions_iam_access_ids" {
+  value = module.github_actions_runner_read_only.access_ids
 }
 
-output "github_actions_iam_secret_key" {
-  value = module.github_actions_runner_read_only.secret_keys[0]
+output "github_actions_iam_secret_keys" {
+  value = module.github_actions_runner_read_only.secret_keys
 }

--- a/aws/modules/util/iam/iam.tf
+++ b/aws/modules/util/iam/iam.tf
@@ -47,13 +47,13 @@ resource "aws_iam_group_membership" "membership" {
 }
 
 output "users" {
-  value = [for key in aws_iam_access_key.key : key.user]
+  value = {for user, access_key in aws_iam_access_key.key : user => access_key.user}
 }
 
 output "access_ids" {
-  value = [for key in aws_iam_access_key.key : key.id]
+  value = {for user, access_key in aws_iam_access_key.key : user => access_key.id}
 }
 
 output "secret_keys" {
-  value = [for key in aws_iam_access_key.key : key.secret]
+  value = {for user, access_key in aws_iam_access_key.key : user => access_key.secret}
 }

--- a/github/organization-secrets.tf
+++ b/github/organization-secrets.tf
@@ -25,7 +25,7 @@ resource "github_actions_organization_secret" "cargo_deny_version" {
 resource "github_actions_organization_secret" "terraform_aws_access_key" {
   secret_name     = "TF_AWS_ACCESS_KEY"
   visibility      = "selected"
-  plaintext_value = data.terraform_remote_state.aws.outputs.github_actions_iam_access_id
+  plaintext_value = data.terraform_remote_state.aws.outputs.github_actions_iam_access_ids["project-infrastructure"]
 
   selected_repository_ids = [github_repository.project_infrastructure.repo_id]
 }
@@ -33,7 +33,7 @@ resource "github_actions_organization_secret" "terraform_aws_access_key" {
 resource "github_actions_organization_secret" "terraform_aws_secret_key" {
   secret_name     = "TF_AWS_SECRET_KEY"
   visibility      = "selected"
-  plaintext_value = data.terraform_remote_state.aws.outputs.github_actions_iam_secret_key
+  plaintext_value = data.terraform_remote_state.aws.outputs.github_actions_iam_secret_keys["project-infrastructure"]
 
   selected_repository_ids = [github_repository.project_infrastructure.repo_id]
 }


### PR DESCRIPTION
Refactor AWS IAM module `users`, `access_ids`, and `secret_keys` outputs
to use a map keyed by the given users rather than a flat list.

This change allows the github bulkhead to select the AWS access keys
associated with specific repositories, rather than arbitrarily indexing
into a list, which improves the robustness of cross-bulkhead state
sharing.

Additionally, this change enables restructuring the AWS module's
readable output to group access key IDs and secret keys by IAM user.