### PR TITLE
Add docs for infra accounts

### DIFF
--- a/docs/aws-accounts.md
+++ b/docs/aws-accounts.md
@@ -1,0 +1,7 @@
+# AWS Accounts
+
+| Internal Domain   | Account ID   | AWS Short Name | Root Credential      | Description             | Who Are Admins? | Root MFA? |
+| ----------------- | ------------ | -------------- | -------------------- | ----------------------- | --------------- | --------- |
+| artichokeruby.org | 483418563922 | artichokeruby  | AWS - Artichoke Ruby | Mainland infrastructure | [@lopopolo]     | ✅        |
+
+[@lopopolo]: https://github.com/lopopolo

--- a/docs/crates.io.md
+++ b/docs/crates.io.md
@@ -1,0 +1,15 @@
+# crates.io
+
+## Crate Owners
+
+| Type        | GitHub Account                    | crates.io Profile                | Who Are Admins? |
+| ----------- | --------------------------------- | -------------------------------- | --------------- |
+| User        | [@lopopolo]                       | [@lopopolo][crates.io-lopopolo]  | [@lopopolo]     |
+| GitHub Team | [@artichoke/crates-io-publishers] | [artichoke crates.io publishers] | [@lopopolo]     |
+
+[@lopopolo]: https://github.com/lopopolo
+[crates.io-lopopolo]: https://crates.io/users/lopopolo
+[@artichoke/crates-io-publishers]:
+  https://github.com/orgs/artichoke/teams/crates-io-publishers
+[artichoke crates.io publishers]:
+  https://crates.io/teams/github:artichoke:crates-io-publishers

--- a/docs/domains.md
+++ b/docs/domains.md
@@ -1,0 +1,13 @@
+# Domain Names
+
+| Domain             | Registrar      | Description                                   | Subdomains                                                      | Content Type | HTTPS Enabled? | MX Records in Google Workspace? |
+| ------------------ | -------------- | --------------------------------------------- | --------------------------------------------------------------- | ------------ | -------------- | ------------------------------- |
+| artichoke-ruby.com | Google Domains | Redirects to <https://www.artichokeruby.org/> | apex, www                                                       | Redirect     | ✅             | ✅                              |
+| artichoke-ruby.net | Google Domains | Redirects to <https://www.artichokeruby.org/> | apex, www                                                       | Redirect     | ✅             | ✅                              |
+| artichoke-ruby.org | Google Domains | Redirects to <https://www.artichokeruby.org/> | apex, www                                                       | Redirect     | ✅             | ✅                              |
+| artichoke-ruby.run | Google Domains | Redirects to <https://artichoke.run/>         | apex, www                                                       | Redirect     | ✅             | ✅                              |
+| artichoke.run      | Google Domains | Wasm playground                               | apex, www redirects to apex, rubyconf2019 hosts an old snapshot | Webapp       | ✅             | ✅                              |
+| artichokeruby.com  | Google Domains | Redirects to <https://www.artichokeruby.org/> | apex, www                                                       | Redirect     | ✅             | ✅                              |
+| artichokeruby.net  | Google Domains | Redirects to <https://www.artichokeruby.org/> | apex, www                                                       | Redirect     | ✅             | ✅                              |
+| artichokeruby.org  | Google Domains | Project website                               | apex redirects to www, www                                      | Webapp       | ✅             | ✅                              |
+| artichokeruby.run  | Google Domains | Redirects to <https://artichoke.run/>         | apex, www                                                       | Redirect     | ✅             | ✅                              |

--- a/docs/github-accounts.md
+++ b/docs/github-accounts.md
@@ -1,0 +1,22 @@
+# GitHub Accounts
+
+## Organizations
+
+| Organization     | Display Name               | Billing Plan | Description                                                    | Who Are Admins? | 2FA Required? |
+| ---------------- | -------------------------- | ------------ | -------------------------------------------------------------- | --------------- | ------------- |
+| [artichoke]      | Artichoke Ruby             | GitHub Free  | Primary organization, home of all development                  | [@lopopolo]     | ✅            |
+| [artichokeruby]  | Artichoke Ruby (alternate) | GitHub Free  | Alternate GitHub organization to protect a [package scope]     | [@lopopolo]     | ✅            |
+| [artichoke-ruby] | Artichoke Ruby (alternate) | GitHub Free  | Alternate GitHub organization to protect against typosquatting | [@lopopolo]     | ✅            |
+
+## Machine Users
+
+| Username        | Display Name | Billing Plan |
+| --------------- | ------------ | ------------ |
+| [@artichoke-ci] | Artichoke CI | GitHub Free  |
+
+[artichoke]: https://github.com/artichoke
+[artichokeruby]: https://github.com/artichokeruby
+[artichoke-ruby]: https://github.com/artichoke-ruby
+[package scope]: npm.md#scopes
+[@lopopolo]: https://github.com/lopopolo
+[@artichoke-ci]: https://github.com/artichoke-ci

--- a/docs/npm.md
+++ b/docs/npm.md
@@ -1,0 +1,10 @@
+# NPM
+
+## Scopes
+
+| Scope           | Billing Plan | Description                                          | Who Are Admins? | 2FA Required? |
+| --------------- | ------------ | ---------------------------------------------------- | --------------- | ------------- |
+| @artichokeruby  | Free         | Primary scope, used for publishing packages          | [@lopopolo]     | ✅            |
+| @artichoke-ruby | Free         | Alternate NPM scope to protect against typosquatting | [@lopopolo]     | ✅            |
+
+[@lopopolo]: https://www.npmjs.com/~lopopolo


### PR DESCRIPTION
Add docs for accounts and owners on AWS, GitHub, NPM, crates.io, and Google Domains.