### PR TITLE
Manage Audit GitHub Workflow for Rust repositories with terraform

### DIFF
--- a/github/.terraform.lock.hcl
+++ b/github/.terraform.lock.hcl
@@ -1,6 +1,23 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/template" {
+  version = "2.2.0"
+  hashes = [
+    "h1:0wlehNaxBX7GJQnPfQwTNvvAf38Jm0Nv7ssKGMaG6Og=",
+    "zh:01702196f0a0492ec07917db7aaa595843d8f171dc195f4c988d2ffca2a06386",
+    "zh:09aae3da826ba3d7df69efeb25d146a1de0d03e951d35019a0f80e4f58c89b53",
+    "zh:09ba83c0625b6fe0a954da6fbd0c355ac0b7f07f86c91a2a97849140fea49603",
+    "zh:0e3a6c8e16f17f19010accd0844187d524580d9fdb0731f675ffcf4afba03d16",
+    "zh:45f2c594b6f2f34ea663704cc72048b212fe7d16fb4cfd959365fa997228a776",
+    "zh:77ea3e5a0446784d77114b5e851c970a3dde1e08fa6de38210b8385d7605d451",
+    "zh:8a154388f3708e3df5a69122a23bdfaf760a523788a5081976b3d5616f7d30ae",
+    "zh:992843002f2db5a11e626b3fc23dc0c87ad3729b3b3cff08e32ffb3df97edbde",
+    "zh:ad906f4cebd3ec5e43d5cd6dc8f4c5c9cc3b33d2243c89c5fc18f97f7277b51d",
+    "zh:c979425ddb256511137ecd093e23283234da0154b7fa8b21c2687182d9aea8b2",
+  ]
+}
+
 provider "registry.terraform.io/integrations/github" {
   version     = "4.5.1"
   constraints = "~> 4.5"

--- a/github/README.md
+++ b/github/README.md
@@ -14,4 +14,4 @@ $ terraform apply
 [terraform]: https://www.terraform.io
 [artichoke]: https://github.com/artichoke
 [github access token]:
-  https://github.com/settings/tokens/new?scopes=repo,admin:org,admin:org_hook
+  https://github.com/settings/tokens/new?scopes=repo,admin:org,admin:org_hook,workflow

--- a/github/files/workflows/rust-audit.yaml.tpl
+++ b/github/files/workflows/rust-audit.yaml.tpl
@@ -1,0 +1,33 @@
+---
+name: Audit
+"on":
+  push:
+    branches:
+      - trunk
+  pull_request:
+    branches:
+      - trunk
+  schedule:
+    - cron: "0 0 * * TUE"
+jobs:
+  rust:
+    name: Audit Rust Dependencies
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Setup cargo-deny
+        run: |
+          release_base="https://github.com/EmbarkStudios/cargo-deny/releases/download"
+          version="${cargo_deny_version}"
+          cargo_deny_tarball="$release_base/$version/cargo-deny-$version-x86_64-unknown-linux-musl.tar.gz"
+          echo "Downloading cargo-deny $version from $cargo_deny_tarball."
+          curl -sL "$cargo_deny_tarball" | sudo tar xvz -C /usr/local/bin/ --strip-components=1
+
+      - name: cargo-deny version
+        run: cargo-deny --version
+
+      - name: Run cargo-deny
+        run: cargo-deny check --show-stats

--- a/github/github-actions-workflow-rust-audit.tf
+++ b/github/github-actions-workflow-rust-audit.tf
@@ -1,0 +1,75 @@
+locals {
+  // Set `cargo_deny_force_bump` to true to create branches for PRs that update
+  // the `cargo-deny` version used in the `Audit` workflow.
+  cargo_deny_force_bump = false
+  // https://github.com/EmbarkStudios/cargo-deny/releases/tag/0.8.9
+  cargo_deny_version = "0.8.9"
+  rust_audit_repos = {
+    artichoke  = "artichoke"  // https://github.com/artichoke/artichoke
+    boba       = "boba"       // https://github.com/artichoke/boba
+    focaccia   = "focaccia"   // https://github.com/artichoke/focaccia
+    intaglio   = "intaglio"   // https://github.com/artichoke/intaglio
+    playground = "playground" // https://github.com/artichoke/playground
+    rand_mt    = "rand_mt"    // https://github.com/artichoke/rand_mt
+    roe        = "roe"        // https://github.com/artichoke/roe
+    strudel    = "strudel"    // https://github.com/artichoke/strudel
+  }
+}
+
+data "template_file" "github_actions_workflow_rust_audit" {
+  template = file("${path.module}/files/workflows/rust-audit.yaml.tpl")
+  vars = {
+    cargo_deny_version = local.cargo_deny_version
+  }
+}
+
+data "github_branch" "github_actions_workflow_rust_audit_sync_base" {
+  for_each = local.rust_audit_repos
+
+  repository = each.value
+  branch     = "trunk"
+
+  depends_on = [
+    github_repository.artichoke,
+    github_repository.boba,
+    github_repository.focaccia,
+    github_repository.intaglio,
+    github_repository.playground,
+    github_repository.rand_mt,
+    github_repository.roe,
+    github_repository.strudel,
+  ]
+}
+
+resource "github_branch" "github_actions_workflows_rust_audit_pr_branch" {
+  for_each = local.cargo_deny_force_bump ? local.rust_audit_repos : {}
+
+  repository    = each.value
+  branch        = "terraform/github_actions_workflows_sync_rust_audit"
+  source_branch = "trunk"
+  source_sha    = data.github_branch.github_actions_workflow_rust_audit_sync_base[each.key].sha
+}
+
+resource "github_repository_file" "github_actions_workflows_sync_rust_audit" {
+  for_each = local.cargo_deny_force_bump ? local.rust_audit_repos : {}
+
+  repository          = each.value
+  branch              = "terraform/github_actions_workflows_sync_rust_audit"
+  file                = ".github/workflows/audit.yaml"
+  content             = data.template_file.github_actions_workflow_rust_audit.rendered
+  commit_message      = "Update cargo-deny version to ${local.cargo_deny_version} in audit workflow\n\nManaged by Terraform"
+  commit_author       = "artichoke-ci"
+  commit_email        = "ci@artichokeruby.org"
+  overwrite_on_create = true
+
+  depends_on = [
+    github_branch.github_actions_workflows_rust_audit_pr_branch["artichoke"],
+    github_branch.github_actions_workflows_rust_audit_pr_branch["boba"],
+    github_branch.github_actions_workflows_rust_audit_pr_branch["focaccia"],
+    github_branch.github_actions_workflows_rust_audit_pr_branch["intaglio"],
+    github_branch.github_actions_workflows_rust_audit_pr_branch["playground"],
+    github_branch.github_actions_workflows_rust_audit_pr_branch["rand_mt"],
+    github_branch.github_actions_workflows_rust_audit_pr_branch["roe"],
+    github_branch.github_actions_workflows_rust_audit_pr_branch["strudel"],
+  ]
+}

--- a/github/organization-secrets.tf
+++ b/github/organization-secrets.tf
@@ -12,16 +12,6 @@ data "terraform_remote_state" "aws" {
   }
 }
 
-locals {
-  cargo_deny_version = "0.8.8"
-}
-
-resource "github_actions_organization_secret" "cargo_deny_version" {
-  secret_name     = "CARGO_DENY_VERSION"
-  visibility      = "all"
-  plaintext_value = "version=${local.cargo_deny_version}"
-}
-
 resource "github_actions_organization_secret" "terraform_aws_access_key" {
   secret_name     = "TF_AWS_ACCESS_KEY"
   visibility      = "selected"


### PR DESCRIPTION
The `audit.yaml` workflow in Rust repositories has been toilsome to
update when new `cargo-deny` releases are made. To work around this,
configuration for the `cargo-deny` version was centrally managed via an
organization secret. This secret was managed with terraform as of #54.

Secrets are not visible to PRs from forks, which meant that PRs to
artichoke/artichoke would fail the audit workflow. To work around this,
manual PRs were issued across all Rust repositories to add a fallback
`cargo-deny` version in the bash script for the installer task. See
artichoke/artichoke#1013 for an example PR.

The 0.8.9 release of `cargo-deny` fixes a bug caused by the main branch
changing of a runtime dependency on the rust advisory DB. This has the
potential to break the workflow when the fallback version is invoked.

To fix this issue moving forward, this commit manages the
`.github/workflows/audit.yaml` file for all Rust repositories in the
artichoke organization. The `cargo-deny` version is controlled with a
terraform local and there is no dependency on any organization secrets.

When the `cargo-deny` version changes, operators should toggle the
`cargo_deny_force_bump` local to true and update the `cargo-deny`
version in the `cargo_deny_version` local.

A subsequent `terraform apply` will create new branches in all Rust
repos with an updated GitHub Actions workflow file. These branches can
be turned into PRs which will run status checks and update the workflow.

This commit updates the `cargo-deny` version to 0.8.9 and removes the
`CARGO_DENY_VERSION` organization secret.