### PR TITLE
Add dependabot configuration for Ruby

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,17 @@
 ---
 version: 2
 updates:
+  - package-ecosystem: bundler
+    directory: "/"
+    schedule:
+      interval: daily
+    allow:
+      - dependency-type: "all"
+    open-pull-requests-limit: 10
+    assignees:
+      - lopopolo
+    labels:
+      - A-deps
   - package-ecosystem: npm
     directory: "/"
     schedule:


### PR DESCRIPTION
`Gemfile` and `Rakefile` were added in #53.