### PR TITLE
Manage .ruby-version toolchain file with Terraform

### DIFF
--- a/github/files/ruby-version.tpl
+++ b/github/files/ruby-version.tpl
@@ -1,0 +1,1 @@
+${ruby_version}

--- a/github/ruby-version.tf
+++ b/github/ruby-version.tf
@@ -1,7 +1,7 @@
 locals {
   // Set `ruby_version_force_bump` to true to create branches for PRs that
   // update the `.ruby-version` version used in each repository.
-  ruby_version_force_bump = true
+  ruby_version_force_bump = false
   // https://github.com/ruby/ruby/tree/v3_0_2
   ruby_version = "3.0.2"
   ruby_version_repos = {
@@ -63,7 +63,7 @@ resource "github_repository_file" "ruby_version" {
 
   repository          = each.value
   branch              = "terraform/ruby_version_bump"
-  file                = ".github/workflows/audit.yaml"
+  file                = ".ruby-version"
   content             = data.template_file.ruby_version.rendered
   commit_message      = "Update Ruby toolchain version to ${local.ruby_version} in .ruby-version\n\nManaged by Terraform"
   commit_author       = "artichoke-ci"
@@ -71,18 +71,18 @@ resource "github_repository_file" "ruby_version" {
   overwrite_on_create = true
 
   depends_on = [
-    github_branch.github_actions_workflows_rust_audit_pr_branch["artichoke"],
-    github_branch.github_actions_workflows_rust_audit_pr_branch["artichoke_github_io"],
-    github_branch.github_actions_workflows_rust_audit_pr_branch["boba"],
-    github_branch.github_actions_workflows_rust_audit_pr_branch["cactusref"],
-    github_branch.github_actions_workflows_rust_audit_pr_branch["focaccia"],
-    github_branch.github_actions_workflows_rust_audit_pr_branch["intaglio"],
-    github_branch.github_actions_workflows_rust_audit_pr_branch["playground"],
-    github_branch.github_actions_workflows_rust_audit_pr_branch["project_infrastructure"],
-    github_branch.github_actions_workflows_rust_audit_pr_branch["rand_mt"],
-    github_branch.github_actions_workflows_rust_audit_pr_branch["roe"],
-    github_branch.github_actions_workflows_rust_audit_pr_branch["rubyconf"],
-    github_branch.github_actions_workflows_rust_audit_pr_branch["strudel"],
+    github_branch.ruby_version_pr_branch["artichoke"],
+    github_branch.ruby_version_pr_branch["artichoke_github_io"],
+    github_branch.ruby_version_pr_branch["boba"],
+    github_branch.ruby_version_pr_branch["cactusref"],
+    github_branch.ruby_version_pr_branch["focaccia"],
+    github_branch.ruby_version_pr_branch["intaglio"],
+    github_branch.ruby_version_pr_branch["playground"],
+    github_branch.ruby_version_pr_branch["project_infrastructure"],
+    github_branch.ruby_version_pr_branch["rand_mt"],
+    github_branch.ruby_version_pr_branch["roe"],
+    github_branch.ruby_version_pr_branch["rubyconf"],
+    github_branch.ruby_version_pr_branch["strudel"],
   ]
 }
 
@@ -90,10 +90,10 @@ resource "github_repository_pull_request" "ruby_version" {
   for_each = local.ruby_version_force_bump ? local.ruby_version_repos : {}
 
   base_repository = each.value
-  base_ref        = "trunk"
-  head_ref        = github_branch.github_actions_workflows_rust_audit_pr_branch[each.key]
+  base_ref        = data.github_branch.ruby_version_sync_base[each.key].ref
+  head_ref        = github_branch.ruby_version_pr_branch[each.key].ref
   title           = "Update Ruby toolchain version to ${local.ruby_version} in .ruby-version"
-  body            = "Managed by terraform.\n\nRuby 2.6.x has entered security maintenance mode.\n\nhttps://www.ruby-lang.org/en/news/2021/07/07/ruby-2-6-8-released/"
+  body            = "Managed by terraform."
 
   maintainer_can_modify = true
 }

--- a/github/ruby-version.tf
+++ b/github/ruby-version.tf
@@ -112,3 +112,24 @@ resource "github_repository_pull_request" "ruby_version" {
     github_repository_file.ruby_version["strudel"],
   ]
 }
+
+output "prs" {
+  value = <<CONFIG
+
+Pull Requests:
+${join(
+  "\n",
+  formatlist(
+    "%s",
+    [for repo in keys(local.ruby_version_repos) :
+      join("/", [
+        "https://github.com/artichoke",
+        local.ruby_version_repos[repo],
+        "pull",
+        github_repository_pull_request.ruby_version[repo].number,
+      ])
+    ]
+))}
+
+CONFIG
+}

--- a/github/ruby-version.tf
+++ b/github/ruby-version.tf
@@ -1,0 +1,99 @@
+locals {
+  // Set `ruby_version_force_bump` to true to create branches for PRs that
+  // update the `.ruby-version` version used in each repository.
+  ruby_version_force_bump = false
+  // https://github.com/ruby/ruby/tree/v3_0_2
+  ruby_version = "3.0.2"
+  ruby_version_repos = {
+    artichoke              = "artichoke"              // https://github.com/artichoke/artichoke
+    artichoke_github_io    = "artichoke.github.io"    // https://github.com/artichoke/artichoke.github.io
+    boba                   = "boba"                   // https://github.com/artichoke/boba
+    cactusref              = "cactusref"              // https://github.com/artichoke/cactusref
+    focaccia               = "focaccia"               // https://github.com/artichoke/focaccia
+    intaglio               = "intaglio"               // https://github.com/artichoke/intaglio
+    playground             = "playground"             // https://github.com/artichoke/playground
+    project_infrastructure = "project-infrastructure" // https://github.com/artichoke/project-infrastructure
+    rand_mt                = "rand_mt"                // https://github.com/artichoke/rand_mt
+    roe                    = "roe"                    // https://github.com/artichoke/roe
+    rubyconf               = "rubyconf"               // https://github.com/artichoke/rubyconf
+    strudel                = "strudel"                // https://github.com/artichoke/strudel
+  }
+}
+
+data "template_file" "ruby_version" {
+  template = file("${path.module}/files/ruby-version.tpl")
+  vars = {
+    ruby_version = local.ruby_version
+  }
+}
+
+data "github_branch" "ruby_version_sync_base" {
+  for_each = local.ruby_version_repos
+
+  repository = each.value
+  branch     = "trunk"
+
+  depends_on = [
+    github_repository.artichoke,
+    github_repository.artichoke_github_io,
+    github_repository.boba,
+    github_repository.cactusref,
+    github_repository.focaccia,
+    github_repository.intaglio,
+    github_repository.playground,
+    github_repository.project_infrastructure,
+    github_repository.rand_mt,
+    github_repository.roe,
+    github_repository.rubyconf,
+    github_repository.strudel,
+  ]
+}
+
+resource "github_branch" "ruby_version_pr_branch" {
+  for_each = local.ruby_version_force_bump ? local.ruby_version_repos : {}
+
+  repository    = each.value
+  branch        = "terraform/ruby_version_bump"
+  source_branch = "trunk"
+  source_sha    = data.github_branch.ruby_version_sync_base[each.key].sha
+}
+
+resource "github_repository_file" "ruby_version" {
+  for_each = local.ruby_version_force_bump ? local.ruby_version_repos : {}
+
+  repository          = each.value
+  branch              = "terraform/ruby_version_bump"
+  file                = ".github/workflows/audit.yaml"
+  content             = data.template_file.ruby_version.rendered
+  commit_message      = "Update Ruby toolchain version to ${local.ruby_version} in .ruby-version\n\nManaged by Terraform"
+  commit_author       = "artichoke-ci"
+  commit_email        = "ci@artichokeruby.org"
+  overwrite_on_create = true
+
+  depends_on = [
+    github_branch.github_actions_workflows_rust_audit_pr_branch["artichoke"],
+    github_branch.github_actions_workflows_rust_audit_pr_branch["artichoke_github_io"],
+    github_branch.github_actions_workflows_rust_audit_pr_branch["boba"],
+    github_branch.github_actions_workflows_rust_audit_pr_branch["cactusref"],
+    github_branch.github_actions_workflows_rust_audit_pr_branch["focaccia"],
+    github_branch.github_actions_workflows_rust_audit_pr_branch["intaglio"],
+    github_branch.github_actions_workflows_rust_audit_pr_branch["playground"],
+    github_branch.github_actions_workflows_rust_audit_pr_branch["project_infrastructure"],
+    github_branch.github_actions_workflows_rust_audit_pr_branch["rand_mt"],
+    github_branch.github_actions_workflows_rust_audit_pr_branch["roe"],
+    github_branch.github_actions_workflows_rust_audit_pr_branch["rubyconf"],
+    github_branch.github_actions_workflows_rust_audit_pr_branch["strudel"],
+  ]
+}
+
+resource "github_repository_pull_request" "ruby_version" {
+  for_each = local.ruby_version_force_bump ? local.ruby_version_repos : {}
+
+  base_repository = each.value
+  base_ref        = "trunk"
+  head_ref        = github_branch.github_actions_workflows_rust_audit_pr_branch[each.key]
+  title           = "Update Ruby toolchain version to ${local.ruby_version} in .ruby-version"
+  body            = "Managed by terraform"
+
+  maintainer_can_modify = true
+}

--- a/github/ruby-version.tf
+++ b/github/ruby-version.tf
@@ -96,4 +96,19 @@ resource "github_repository_pull_request" "ruby_version" {
   body            = "Managed by terraform."
 
   maintainer_can_modify = true
+
+  depends_on = [
+    github_repository_file.ruby_version["artichoke"],
+    github_repository_file.ruby_version["artichoke_github_io"],
+    github_repository_file.ruby_version["boba"],
+    github_repository_file.ruby_version["cactusref"],
+    github_repository_file.ruby_version["focaccia"],
+    github_repository_file.ruby_version["intaglio"],
+    github_repository_file.ruby_version["playground"],
+    github_repository_file.ruby_version["project_infrastructure"],
+    github_repository_file.ruby_version["rand_mt"],
+    github_repository_file.ruby_version["roe"],
+    github_repository_file.ruby_version["rubyconf"],
+    github_repository_file.ruby_version["strudel"],
+  ]
 }

--- a/github/ruby-version.tf
+++ b/github/ruby-version.tf
@@ -1,7 +1,7 @@
 locals {
   // Set `ruby_version_force_bump` to true to create branches for PRs that
   // update the `.ruby-version` version used in each repository.
-  ruby_version_force_bump = false
+  ruby_version_force_bump = true
   // https://github.com/ruby/ruby/tree/v3_0_2
   ruby_version = "3.0.2"
   ruby_version_repos = {
@@ -93,7 +93,7 @@ resource "github_repository_pull_request" "ruby_version" {
   base_ref        = "trunk"
   head_ref        = github_branch.github_actions_workflows_rust_audit_pr_branch[each.key]
   title           = "Update Ruby toolchain version to ${local.ruby_version} in .ruby-version"
-  body            = "Managed by terraform"
+  body            = "Managed by terraform.\n\nRuby 2.6.x has entered security maintenance mode.\n\nhttps://www.ruby-lang.org/en/news/2021/07/07/ruby-2-6-8-released/"
 
   maintainer_can_modify = true
 }


### PR DESCRIPTION
Add a new bit of infrastructure as code which can update `.ruby-version` files to a pegged Ruby version string, push up commits with the updates, and create PRs.