### PR TITLE
Address aws-dynamodb-enable-recovery tfsec lint violation

### DIFF
--- a/remote-state/main.tf
+++ b/remote-state/main.tf
@@ -49,6 +49,10 @@ resource "aws_dynamodb_table" "terraform_statelock" {
   write_capacity = 20
   hash_key       = "LockID"
 
+  point_in_time_recovery {
+    enabled = true
+  }
+
   server_side_encryption {
     enabled = true
   }


### PR DESCRIPTION
Followup to https://github.com/artichoke/project-infrastructure/pull/112.

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table#point_in_time_recovery

https://tfsec.dev/docs/aws/dynamodb/enable-recovery/#aws/dynamodb