### PR TITLE
Set additional parameters on `aws_iam_account_password_policy`

### DIFF
--- a/aws/iam.tf
+++ b/aws/iam.tf
@@ -7,4 +7,7 @@ resource "aws_iam_account_password_policy" "this" {
   require_symbols              = true
 
   allow_users_to_change_password = true
+  max_password_age               = 90
+  password_reuse_prevention      = 5
+  hard_expiry                    = false
 }


### PR DESCRIPTION
Followup to #112.

Following the docs here:

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_account_password_policy

Address `aws-iam-no-password-reuse` tfsec lint violation.

https://tfsec.dev/docs/aws/iam/no-password-reuse#aws/iam

Address `aws-iam-set-max-password-age` tfsec lint violation.

https://tfsec.dev/docs/aws/iam/set-max-password-age#aws/iam

Also set `hard_expiry` explicitly to `false`.