### PR TITLE
Add S3 bucket access logging to Artichoke terraform remote state

### DIFF
--- a/remote-state/main.tf
+++ b/remote-state/main.tf
@@ -27,6 +27,11 @@ resource "aws_s3_bucket" "this" {
     }
   }
 
+  logging {
+    target_bucket = aws_s3_bucket.state_access_logs.id
+    target_prefix = "v1/"
+  }
+
   lifecycle {
     prevent_destroy = true
   }
@@ -34,6 +39,72 @@ resource "aws_s3_bucket" "this" {
 
 resource "aws_s3_bucket_public_access_block" "this" {
   bucket = aws_s3_bucket.this.id
+
+  block_public_acls   = true
+  block_public_policy = true
+
+  ignore_public_acls = true
+
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket" "state_access_logs" {
+  bucket = "artichoke-forge-project-infrastructure-terraform-state-logs"
+  acl    = "log-delivery-write"
+
+  versioning {
+    enabled    = true
+    mfa_delete = false
+  }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "aws:kms"
+      }
+    }
+  }
+
+  lifecycle_rule {
+    id      = "archive"
+    enabled = true
+
+    tags = {
+      rule      = "archive"
+      autoclean = "true"
+    }
+
+    transition {
+      days          = 30
+      storage_class = "STANDARD_IA"
+    }
+
+    transition {
+      days          = 60
+      storage_class = "GLACIER"
+    }
+
+    expiration {
+      days = 90
+    }
+
+    noncurrent_version_transition {
+      days          = 30
+      storage_class = "GLACIER"
+    }
+
+    noncurrent_version_expiration {
+      days = 60
+    }
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "state_access_logs" {
+  bucket = aws_s3_bucket.state_access_logs.id
 
   block_public_acls   = true
   block_public_policy = true


### PR DESCRIPTION
Followup to #112.

Address `aws-s3-enable-bucket-logging` tfsec lint violation.

https://tfsec.dev/docs/aws/s3/enable-bucket-logging/#aws/s3