### PR TITLE
Add missing PR orchestration resource dependencies for ruby-file-expand-path

### DIFF
--- a/github/github-actions-workflow-rust-audit.tf
+++ b/github/github-actions-workflow-rust-audit.tf
@@ -40,6 +40,7 @@ data "github_branch" "github_actions_workflow_rust_audit_sync_base" {
     github_repository.playground,
     github_repository.rand_mt,
     github_repository.roe,
+    github_repository.ruby_file_expand_path,
     github_repository.strudel,
   ]
 }
@@ -74,6 +75,7 @@ resource "github_repository_file" "github_actions_workflows_rust_audit" {
     github_branch.github_actions_workflows_rust_audit_pr_branch["playground"],
     github_branch.github_actions_workflows_rust_audit_pr_branch["rand_mt"],
     github_branch.github_actions_workflows_rust_audit_pr_branch["roe"],
+    github_branch.github_actions_workflows_rust_audit_pr_branch["ruby_file_expand_path"],
     github_branch.github_actions_workflows_rust_audit_pr_branch["strudel"],
   ]
 }
@@ -98,6 +100,7 @@ resource "github_repository_pull_request" "github_actions_workflow_rust_audit" {
     github_repository_file.github_actions_workflows_rust_audit["playground"],
     github_repository_file.github_actions_workflows_rust_audit["rand_mt"],
     github_repository_file.github_actions_workflows_rust_audit["roe"],
+    github_repository_file.github_actions_workflows_rust_audit["ruby_file_expand_path"],
     github_repository_file.github_actions_workflows_rust_audit["strudel"],
   ]
 }

--- a/github/ruby-version.tf
+++ b/github/ruby-version.tf
@@ -48,6 +48,7 @@ data "github_branch" "ruby_version_sync_base" {
     github_repository.rand_mt,
     github_repository.roe,
     github_repository.rubyconf,
+    github_repository.ruby_file_expand_path,
     github_repository.strudel,
   ]
 }
@@ -85,6 +86,7 @@ resource "github_repository_file" "ruby_version" {
     github_branch.ruby_version_pr_branch["rand_mt"],
     github_branch.ruby_version_pr_branch["roe"],
     github_branch.ruby_version_pr_branch["rubyconf"],
+    github_branch.ruby_version_pr_branch["ruby_file_expand_path"],
     github_branch.ruby_version_pr_branch["strudel"],
   ]
 }
@@ -112,6 +114,7 @@ resource "github_repository_pull_request" "ruby_version" {
     github_repository_file.ruby_version["rand_mt"],
     github_repository_file.ruby_version["roe"],
     github_repository_file.ruby_version["rubyconf"],
+    github_repository_file.ruby_version["ruby_file_expand_path"],
     github_repository_file.ruby_version["strudel"],
   ]
 }


### PR DESCRIPTION
Followup to https://github.com/artichoke/project-infrastructure/pull/102.