### PR TITLE
Bring back tfsec audit workflow

### DIFF
--- a/.github/workflows/tfsec.yaml
+++ b/.github/workflows/tfsec.yaml
@@ -1,0 +1,79 @@
+---
+name: tfsec
+"on":
+  push:
+    branches:
+      - trunk
+  pull_request:
+    branches:
+      - trunk
+  schedule:
+    - cron: "0 0 * * TUE"
+jobs:
+  terraform:
+    name: Audit Terraform Infrastructure as Code
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.TF_AWS_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.TF_AWS_SECRET_KEY }}
+          aws-region: us-west-2
+
+      - name: "Setup Terraform"
+        uses: hashicorp/setup-terraform@v1
+        with:
+          terraform_version: 1.x
+
+      - name: "terraform init"
+        run: |
+          terraform -chdir=aws init
+          terraform -chdir=github init
+          terraform -chdir=remote-state init
+      - name: "tfsec aws"
+        uses: docker://tfsec/tfsec:latest
+        id: tfsec_aws
+        continue-on-error: true
+        with:
+          entrypoint: tfsec
+          args: aws
+
+      - name: "tfsec github"
+        uses: docker://tfsec/tfsec:latest
+        id: tfsec_github
+        continue-on-error: true
+        with:
+          entrypoint: tfsec
+          args: github
+
+      - name: "tfsec remote-state"
+        uses: docker://tfsec/tfsec:latest
+        id: tfsec_remote_state
+        continue-on-error: true
+        with:
+          entrypoint: tfsec
+          args: remote-state
+
+      - name: "Check on failures"
+        run: |
+          failed=""
+          if [[ ${{ steps.tfsec_aws.outcome }} != "success" ]]; then
+            failed="y"
+            echo >&2 "tfsec aws failed"
+          fi
+          if [[ ${{ steps.tfsec_github.outcome }} != "success" ]]; then
+            failed="y"
+            echo >&2 "tfsec github failed"
+          fi
+          if [[ ${{ steps.tfsec_remote_state.outcome }} != "success" ]]; then
+            failed="y"
+            echo >&2 "tfsec remote-state failed"
+          fi
+          if [[ -n "$failed" ]]; then
+            exit 1
+          fi


### PR DESCRIPTION
The `tfsec` GitHub Actions integration which was introduced in #112 was
accidentally removed when unifying the audit workflow across all
Artichoke repositories in #119.

This commit reintroduces the tfsec integration in a separate GitHub
Actions workflow.