### PR TITLE
Remove ignore annotations for GitHub vuln alerts on archived repositories

### DIFF
--- a/github/archived-repos.tf
+++ b/github/archived-repos.tf
@@ -1,4 +1,3 @@
-#tfsec:ignore:github-repositories-vulnerability-alerts
 resource "github_repository" "artichoke_ci" {
   name        = "artichoke-ci"
   description = "🏗 CI infrastructure and images for Artichoke"
@@ -28,7 +27,6 @@ resource "github_repository" "artichoke_ci" {
   }
 }
 
-#tfsec:ignore:github-repositories-vulnerability-alerts
 resource "github_repository" "ferrocarril" {
   name         = "ferrocarril"
   description  = "🚆 Experiments to embed Ruby on Rails in Rust with mruby"
@@ -65,7 +63,6 @@ resource "github_repository" "ferrocarril" {
   }
 }
 
-#tfsec:ignore:github-repositories-vulnerability-alerts
 resource "github_repository" "rust_mersenne_twister" {
   name         = "rust-mersenne-twister"
   description  = "Fork migrated to artichoke/rand_mt"


### PR DESCRIPTION
This has been fixed upstream and released with tfsec 0.59.0.

- aquasecurity/tfsec#1111
- aquasecurity/tfsec#1115