### PR TITLE
Remove long-lived AWSAdministrator access tokens and use aws-vault for terraform

### DIFF
--- a/aws/aws.tf
+++ b/aws/aws.tf
@@ -4,7 +4,6 @@ variable "region" {
 
 provider "aws" {
   region  = var.region
-  profile = "artichoke-forge-project-infrastructure"
 
   default_tags {
     tags = {

--- a/aws/aws.tf
+++ b/aws/aws.tf
@@ -3,7 +3,7 @@ variable "region" {
 }
 
 provider "aws" {
-  region  = var.region
+  region = var.region
 
   default_tags {
     tags = {

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -5,21 +5,11 @@ terraform {
     key            = "aws/terraform.tfstate"
     encrypt        = true
     dynamodb_table = "terraform_statelock"
-
-    profile = "artichoke-forge-project-infrastructure"
   }
 }
 
 variable "name" {
   default = "artichoke-forge"
-}
-
-variable "iam_admins" {
-  type = map(string)
-
-  default = {
-    lopopolo = "lopopolo"
-  }
 }
 
 variable "github_actions_runners" {
@@ -28,12 +18,6 @@ variable "github_actions_runners" {
   default = {
     project-infrastructure = "github-actions-repo-project-infrastructure"
   }
-}
-
-module "administrator_access" {
-  source = "./modules/util/iam-admin"
-
-  users = var.iam_admins
 }
 
 data "aws_iam_policy_document" "github_actions_runner_terraform_state_read_only" {
@@ -72,20 +56,6 @@ module "github_actions_runner_read_only" {
 output "config" {
   value = <<CONFIG
 
-Admin IAM:
-${join(
-  "\n\n",
-  formatlist(
-    "%s",
-    [for user in keys(module.administrator_access.users) :
-      join("\n", [
-        "  user: ${module.administrator_access.users[user]}",
-        "    access id: ${module.administrator_access.access_ids[user]}",
-        "    secret key: ${module.administrator_access.secret_keys[user]}"
-      ])
-    ]
-  ))}
-
 GitHub Actions IAM:
 ${join(
   "\n\n",
@@ -103,20 +73,6 @@ ${join(
 CONFIG
 
 sensitive = true
-}
-
-output "iam_admin_users" {
-  value = module.administrator_access.users
-}
-
-output "iam_admin_access_ids" {
-  value = module.administrator_access.access_ids
-}
-
-output "iam_admin_secret_keys" {
-  value = module.administrator_access.secret_keys
-
-  sensitive = true
 }
 
 output "github_actions_iam_access_ids" {

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,0 +1,50 @@
+# terraform
+
+The configuration in this repository is managed and applied by `terraform`.
+
+This repository uses terraform 1.x.
+
+## Setup
+
+```shell
+brew install terraform
+brew install --cask aws-vault
+```
+
+## AWS Credentials
+
+The `artichokeruby` AWS Organization is set up using Control Tower and its
+account vending machine, which sets up an AWS SSO integration.
+
+No long-lived AWS credentials are required for operators.
+
+[`aws-vault`] has an [integration with AWS SSO][aws-vault-aws-sso] which uses
+SSO and authorized roles to generate temporary access tokens with assume role.
+
+[`aws-vault`]: https://github.com/99designs/aws-vault
+[aws-vault-aws-sso]:
+  https://github.com/99designs/aws-vault/blob/master/USAGE.md#aws-single-sign-on-aws-sso
+
+To set up this integration, add the following config to `$HOME/.aws/config`:
+
+```ini
+[profile artichokeruby-forge-admin]
+sso_start_url=https://d-92670c932c.awsapps.com/start
+sso_region=us-west-2
+sso_account_id=447522982029
+sso_role_name=AWSAdministratorAccess
+```
+
+## Using `terraform` and `aws-vault`
+
+To use the `aws-vault`-generated temporary credentials, invoke terraform like
+this:
+
+```shell
+aws-vault exec artichokeruby-forge-admin -- terraform plan
+aws-vault exec artichokeruby-forge-admin -- terraform apply
+```
+
+This may open a browser window to facilitate an SSO login. It may prompt for a
+macOS keychain password. `aws-vault` stores temporary credentials in a keychain
+that it manages.

--- a/github/main.tf
+++ b/github/main.tf
@@ -5,8 +5,6 @@ terraform {
     key            = "github/terraform.tfstate"
     encrypt        = true
     dynamodb_table = "terraform_statelock"
-
-    profile = "artichoke-forge-project-infrastructure"
   }
 }
 

--- a/github/organization-secrets.tf
+++ b/github/organization-secrets.tf
@@ -7,8 +7,6 @@ data "terraform_remote_state" "aws" {
     key            = "aws/terraform.tfstate"
     encrypt        = true
     dynamodb_table = "terraform_statelock"
-
-    profile = "artichoke-forge-project-infrastructure"
   }
 }
 

--- a/remote-state/aws.tf
+++ b/remote-state/aws.tf
@@ -4,7 +4,6 @@ variable "region" {
 
 provider "aws" {
   region  = var.region
-  profile = "artichoke-forge-project-infrastructure"
 
   default_tags {
     tags = {

--- a/remote-state/aws.tf
+++ b/remote-state/aws.tf
@@ -3,7 +3,7 @@ variable "region" {
 }
 
 provider "aws" {
-  region  = var.region
+  region = var.region
 
   default_tags {
     tags = {

--- a/remote-state/main.tf
+++ b/remote-state/main.tf
@@ -5,8 +5,6 @@ terraform {
     key            = "remote-state/terraform.tfstate"
     encrypt        = true
     dynamodb_table = "terraform_statelock"
-
-    profile = "artichoke-forge-project-infrastructure"
   }
 }
 


### PR DESCRIPTION
Use AWS SSO and assume role + short-lived STS creds to invoke terraform with aws-vault.

This PR includes an already-applied change to remove the `lopopolo` IAM Admin user.