### PR TITLE
Manage raw-parts repository with terraform

### DIFF
--- a/github/github-actions-workflow-audit.tf
+++ b/github/github-actions-workflow-audit.tf
@@ -13,6 +13,7 @@ locals {
     intaglio              = "intaglio"              // https://github.com/artichoke/intaglio
     playground            = "playground"            // https://github.com/artichoke/playground
     rand_mt               = "rand_mt"               // https://github.com/artichoke/rand_mt
+    raw_parts             = "raw-parts"             // https://github.com/artichoke/raw-parts
     roe                   = "roe"                   // https://github.com/artichoke/roe
     ruby_file_expand_path = "ruby-file-expand-path" // https://github.com/artichoke/ruby-file-expand-path
     strudel               = "strudel"               // https://github.com/artichoke/strudel
@@ -41,6 +42,7 @@ locals {
     playground               = "playground"               // https://github.com/artichoke/playground
     project_infrastructure   = "project-infrastructure"   // https://github.com/artichoke/project-infrastructure
     rand_mt                  = "rand_mt"                  // https://github.com/artichoke/rand_mt
+    raw_parts                = "raw-parts"                // https://github.com/artichoke/raw-parts
     roe                      = "roe"                      // https://github.com/artichoke/roe
     rubyconf                 = "rubyconf"                 // https://github.com/artichoke/rubyconf
     ruby_file_expand_path    = "ruby-file-expand-path"    // https://github.com/artichoke/ruby-file-expand-path
@@ -62,6 +64,7 @@ locals {
     playground               = "playground"               // https://github.com/artichoke/playground
     project_infrastructure   = "project-infrastructure"   // https://github.com/artichoke/project-infrastructure
     rand_mt                  = "rand_mt"                  // https://github.com/artichoke/rand_mt
+    raw_parts                = "raw-parts"                // https://github.com/artichoke/raw-parts
     roe                      = "roe"                      // https://github.com/artichoke/roe
     rubyconf                 = "rubyconf"                 // https://github.com/artichoke/rubyconf
     ruby_file_expand_path    = "ruby-file-expand-path"    // https://github.com/artichoke/ruby-file-expand-path

--- a/github/repos.tf
+++ b/github/repos.tf
@@ -484,6 +484,43 @@ resource "github_repository" "rand_mt" {
   }
 }
 
+resource "github_repository" "raw_parts" {
+  name         = "raw-parts"
+  description  = "🪣 Types for a `Vec`'s raw parts"
+  homepage_url = "https://crates.io/crates/raw-parts"
+
+  visibility = "public"
+
+  has_downloads = true
+  has_issues    = true
+  has_projects  = false
+  has_wiki      = false
+
+  delete_branch_on_merge = true
+  vulnerability_alerts   = true
+
+  topics = [
+    "artichoke",
+    "ffi",
+    "no-std",
+    "pointers",
+    "rust",
+    "rust-crate",
+    "vector",
+  ]
+
+  pages {
+    source {
+      branch = "gh-pages"
+      path   = "/"
+    }
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
 resource "github_repository" "roe" {
   name         = "roe"
   description  = "🍣 Unicode case converters"

--- a/github/ruby-version.tf
+++ b/github/ruby-version.tf
@@ -16,6 +16,7 @@ locals {
     playground               = "playground"               // https://github.com/artichoke/playground
     project_infrastructure   = "project-infrastructure"   // https://github.com/artichoke/project-infrastructure
     rand_mt                  = "rand_mt"                  // https://github.com/artichoke/rand_mt
+    raw_parts                = "raw-parts"                // https://github.com/artichoke/raw-parts
     roe                      = "roe"                      // https://github.com/artichoke/roe
     rubyconf                 = "rubyconf"                 // https://github.com/artichoke/rubyconf
     ruby_file_expand_path    = "ruby-file-expand-path"    // https://github.com/artichoke/ruby-file-expand-path


### PR DESCRIPTION
This change is already applied.

## terraform apply

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following
symbols:
  ~ update in-place

Terraform will perform the following actions:

  # github_repository.raw_parts will be updated in-place
  ~ resource "github_repository" "raw_parts" {
      ~ has_wiki               = true -> false
      + homepage_url           = "https://crates.io/crates/raw-parts"
        id                     = "raw-parts"
        name                   = "raw-parts"
      ~ topics                 = [
          + "no-std",
            # (6 unchanged elements hidden)
        ]
        # (25 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Changes to Outputs:
  + github_actions_workflows_audit_pull_requests = <<-EOT
        Pull Requests:
        none
    EOT

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

github_repository.raw_parts: Modifying... [id=raw-parts]
github_repository.raw_parts: Modifications complete after 5s [id=raw-parts]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.

Outputs:

github_actions_workflows_audit_pull_requests = <<EOT
Pull Requests:
none

EOT
ruby_version_pull_requests = <<EOT

Pull Requests:
none


EOT
```