### PR TITLE
Update Rust cargo-deny Audit workflow

### DIFF
--- a/github/files/workflows/audit.yaml.tpl
+++ b/github/files/workflows/audit.yaml.tpl
@@ -52,6 +52,19 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          profile: minimal
+          override: true
+
+      - name: Generate Cargo.lock
+        run: |
+          if [[ ! -f "Cargo.lock" ]]; then
+            cargo generate-lockfile --verbose
+          fi
+
       - name: Setup cargo-deny
         run: |
           release_base="https://github.com/EmbarkStudios/cargo-deny/releases/download"

--- a/github/files/workflows/audit.yaml.tpl
+++ b/github/files/workflows/audit.yaml.tpl
@@ -77,4 +77,4 @@ jobs:
         run: cargo-deny --version
 
       - name: Run cargo-deny
-        run: cargo-deny check --show-stats
+        run: cargo-deny --locked check --show-stats

--- a/github/github-actions-workflow-audit.tf
+++ b/github/github-actions-workflow-audit.tf
@@ -1,7 +1,7 @@
 locals {
   // Set `force_bump` to true to create branches for PRs that update the Audit
   // workflow organization-wide.
-  force_bump = true
+  force_bump = false
 
   // https://github.com/EmbarkStudios/cargo-deny/releases/tag/0.9.1
   cargo_deny_version = "0.9.1"

--- a/github/github-actions-workflow-audit.tf
+++ b/github/github-actions-workflow-audit.tf
@@ -1,7 +1,7 @@
 locals {
   // Set `force_bump` to true to create branches for PRs that update the Audit
   // workflow organization-wide.
-  force_bump = false
+  force_bump = true
 
   // https://github.com/EmbarkStudios/cargo-deny/releases/tag/0.10.1
   cargo_deny_version = "0.10.1"

--- a/github/github-actions-workflow-audit.tf
+++ b/github/github-actions-workflow-audit.tf
@@ -142,24 +142,6 @@ resource "github_repository_file" "github_actions_workflows_audit" {
   overwrite_on_create = true
 }
 
-resource "github_repository_pull_request" "github_actions_workflow_audit" {
-  for_each = local.force_bump ? local.audit_managed_repos : {}
-
-  base_repository = each.value
-  base_ref        = data.github_branch.github_actions_workflows_audit_base[each.key].ref
-  head_ref        = github_branch.github_actions_workflows_audit[each.key].ref
-  title           = "Update Audit GitHub Actions workflow"
-  body            = <<-BODY
-    Managed by Terraform.
-
-    The cargo-deny version is ${local.cargo_deny_version}.
-
-    Pushed commit ${github_repository_file.github_actions_workflows_audit[each.key].commit_sha}.
-  BODY
-
-  maintainer_can_modify = true
-}
-
 output "github_actions_workflows_audit_pull_requests" {
   value = <<-CONFIG
     Pull Requests:
@@ -171,8 +153,7 @@ output "github_actions_workflows_audit_pull_requests" {
       join("/", [
         "https://github.com/artichoke",
         repo,
-        "pull",
-        github_repository_pull_request.github_actions_workflow_audit[slug].number,
+        "pulls",
       ])
     ]
 )) : "none"}

--- a/github/github-actions-workflow-audit.tf
+++ b/github/github-actions-workflow-audit.tf
@@ -1,7 +1,7 @@
 locals {
   // Set `force_bump` to true to create branches for PRs that update the Audit
   // workflow organization-wide.
-  force_bump = false
+  force_bump = true
 
   // https://github.com/EmbarkStudios/cargo-deny/releases/tag/0.9.1
   cargo_deny_version = "0.9.1"

--- a/github/github-actions-workflow-audit.tf
+++ b/github/github-actions-workflow-audit.tf
@@ -1,7 +1,7 @@
 locals {
   // Set `force_bump` to true to create branches for PRs that update the Audit
   // workflow organization-wide.
-  force_bump = true
+  force_bump = false
 
   // https://github.com/EmbarkStudios/cargo-deny/releases/tag/0.10.1
   cargo_deny_version = "0.10.1"

--- a/github/github-actions-workflow-audit.tf
+++ b/github/github-actions-workflow-audit.tf
@@ -106,6 +106,7 @@ data "github_branch" "github_actions_workflows_audit_base" {
     github_repository.playground,
     github_repository.project_infrastructure,
     github_repository.rand_mt,
+    github_repository.raw_parts,
     github_repository.roe,
     github_repository.rubyconf,
     github_repository.ruby_file_expand_path,
@@ -153,7 +154,8 @@ output "github_actions_workflows_audit_pull_requests" {
       join("/", [
         "https://github.com/artichoke",
         repo,
-        "tree/terraform/github_actions_workflows_audit",
+        "tree",
+        "terraform/github_actions_workflows_audit",
       ])
     ]
 )) : "none"}

--- a/github/github-actions-workflow-audit.tf
+++ b/github/github-actions-workflow-audit.tf
@@ -153,7 +153,7 @@ output "github_actions_workflows_audit_pull_requests" {
       join("/", [
         "https://github.com/artichoke",
         repo,
-        "pulls",
+        "tree/terraform/github_actions_workflows_audit",
       ])
     ]
 )) : "none"}

--- a/github/github-actions-workflow-audit.tf
+++ b/github/github-actions-workflow-audit.tf
@@ -3,8 +3,8 @@ locals {
   // workflow organization-wide.
   force_bump = false
 
-  // https://github.com/EmbarkStudios/cargo-deny/releases/tag/0.9.1
-  cargo_deny_version = "0.9.1"
+  // https://github.com/EmbarkStudios/cargo-deny/releases/tag/0.10.1
+  cargo_deny_version = "0.10.1"
   cargo_deny_audit_repos = {
     artichoke             = "artichoke"             // https://github.com/artichoke/artichoke
     boba                  = "boba"                  // https://github.com/artichoke/boba


### PR DESCRIPTION
- Install nightly toolchain and generate `Cargo.lock` if one is not checked into the repo.
- Pass `--locked` to `cargo-deny`.
- Upgrade `cargo-deny` to 0.10.1.

This PR includes changes to the terraform sources to make orchestrating PRs like this less tedious:

- Do not create audit workflow PRs with terraform (with 20+ repos, I keep running into rate limits which puts the terraform state in an inconsistent spot)
- Do not create `.ruby-version` PRs with terraform.
- Add references to `raw-parts` repo as dependencies in a few missed places from #145.
- Update PR orchestration outputs to link to the pushed branch's tree in GitHub.