### PR TITLE
Update cactusref repo link to crates.io

### DIFF
--- a/github/repos.tf
+++ b/github/repos.tf
@@ -112,7 +112,7 @@ resource "github_repository" "boba" {
 resource "github_repository" "cactusref" {
   name         = "cactusref"
   description  = "🌵 Cycle-Aware Reference Counting in Rust"
-  homepage_url = "https://artichoke.github.io/cactusref/cactusref/"
+  homepage_url = "https://crates.io/crates/cactusref"
 
   archived   = false
   visibility = "public"


### PR DESCRIPTION
Point the repo link at https://crates.io/crates/cactusref.