### PR TITLE
Update state and code to reflect that rubyconf2019 repo is archived

### DIFF
--- a/github/archived-repos.tf
+++ b/github/archived-repos.tf
@@ -91,3 +91,45 @@ resource "github_repository" "rust_mersenne_twister" {
     prevent_destroy = true
   }
 }
+
+resource "github_repository" "rubyconf2019_artichoke_run" {
+  name         = "rubyconf2019.artichoke.run"
+  description  = "📸 A snapshot of artichoke.run that runs the playground as of RubyConf 2019"
+  homepage_url = "https://rubyconf2019.artichoke.run/"
+
+  archived   = true
+  visibility = "public"
+
+  has_downloads = true
+  has_issues    = true
+  has_projects  = false
+  has_wiki      = false
+
+  delete_branch_on_merge = true
+  vulnerability_alerts   = false
+
+  topics = [
+    "artichoke",
+    "playground",
+    "programming-language",
+    "ruby",
+    "rust",
+    "rust-application",
+    "snapshot",
+    "wasm",
+    "webassembly",
+  ]
+
+  pages {
+    cname = "rubyconf2019.artichoke.run"
+    source {
+      branch = "gh-pages"
+      path   = "/"
+    }
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+

--- a/github/repos.tf
+++ b/github/repos.tf
@@ -604,46 +604,6 @@ resource "github_repository" "rubyconf" {
   }
 }
 
-resource "github_repository" "rubyconf2019_artichoke_run" {
-  name         = "rubyconf2019.artichoke.run"
-  description  = "📸 A snapshot of artichoke.run that runs the playground as of RubyConf 2019"
-  homepage_url = "https://rubyconf2019.artichoke.run/"
-
-  visibility = "public"
-
-  has_downloads = true
-  has_issues    = true
-  has_projects  = false
-  has_wiki      = false
-
-  delete_branch_on_merge = true
-  vulnerability_alerts   = true
-
-  topics = [
-    "artichoke",
-    "playground",
-    "programming-language",
-    "ruby",
-    "rust",
-    "rust-application",
-    "snapshot",
-    "wasm",
-    "webassembly",
-  ]
-
-  pages {
-    cname = "rubyconf2019.artichoke.run"
-    source {
-      branch = "gh-pages"
-      path   = "/"
-    }
-  }
-
-  lifecycle {
-    prevent_destroy = true
-  }
-}
-
 resource "github_repository" "ruby_file_expand_path" {
   name         = "ruby-file-expand-path"
   description  = "📂 Rust port of path normalization from MRI Ruby."


### PR DESCRIPTION
This change is applied and comes back clean:

```console
$ aws-vault exec artichokeruby-forge-admin -- terraform apply
module.artichokeruby_users.github_membership.members["artichoke-ci"]: Refreshing state... [id=artichokeruby:artichoke-ci]
module.artichokeruby_users.github_membership.admins["lopopolo"]: Refreshing state... [id=artichokeruby:lopopolo]
module.artichoke_ruby_users.github_membership.admins["lopopolo"]: Refreshing state... [id=artichoke-ruby:lopopolo]
module.artichoke_ruby_users.github_membership.members["artichoke-ci"]: Refreshing state... [id=artichoke-ruby:artichoke-ci]
github_repository.roe: Refreshing state... [id=roe]
github_repository.rand_mt: Refreshing state... [id=rand_mt]
github_repository.onigmo: Refreshing state... [id=Onigmo]
github_repository.www_artichokeruby_org: Refreshing state... [id=www.artichokeruby.org]
github_repository.clang_format: Refreshing state... [id=clang-format]
github_repository.mspec: Refreshing state... [id=mspec]
github_repository.mruby: Refreshing state... [id=mruby]
github_repository.docker_artichoke_nightly: Refreshing state... [id=docker-artichoke-nightly]
github_repository.rust_onig: Refreshing state... [id=rust-onig]
github_repository.oniguruma: Refreshing state... [id=oniguruma]
github_repository.ruby_file_expand_path: Refreshing state... [id=ruby-file-expand-path]
github_repository.artichoke_ci: Refreshing state... [id=artichoke-ci]
github_repository.rubyconf2019_artichoke_run: Refreshing state... [id=rubyconf2019.artichoke.run]
github_repository.artichoke: Refreshing state... [id=artichoke]
github_repository.boba: Refreshing state... [id=boba]
github_repository.private_crate_reservation["artichoke"]: Refreshing state... [id=artichoke-reserve]
github_repository.private_crate_reservation["invokedynamic"]: Refreshing state... [id=invokedynamic-reserve]
github_repository.private_crate_reservation["artichokeruby"]: Refreshing state... [id=artichokeruby-reserve]
github_repository.private_crate_reservation["artichoke-ruby"]: Refreshing state... [id=artichoke-ruby-reserve]
github_repository.private_crate_reservation["boba"]: Refreshing state... [id=boba-reserve]
github_repository.rust_mersenne_twister: Refreshing state... [id=rust-mersenne-twister]
github_repository.logo: Refreshing state... [id=logo]
github_repository.nightly: Refreshing state... [id=nightly]
github_repository.ferrocarril: Refreshing state... [id=ferrocarril]
github_repository.playground: Refreshing state... [id=playground]
github_repository.strudel: Refreshing state... [id=strudel]
github_repository.raw_parts: Refreshing state... [id=raw-parts]
github_repository.focaccia: Refreshing state... [id=focaccia]
github_repository.spec: Refreshing state... [id=spec]
github_repository.jasper: Refreshing state... [id=jasper]
module.artichoke_users.github_membership.members["artichoke-ci"]: Refreshing state... [id=artichoke:artichoke-ci]
github_repository.ruby: Refreshing state... [id=ruby]
module.artichoke_users.github_membership.admins["lopopolo"]: Refreshing state... [id=artichoke:lopopolo]
github_repository.artichoke_github_io: Refreshing state... [id=artichoke.github.io]
module.team_cratesio_publishers.github_team.this: Refreshing state... [id=4053636]
github_repository.intaglio: Refreshing state... [id=intaglio]
github_repository.rubyconf: Refreshing state... [id=rubyconf]
module.team_ci.github_team.this: Refreshing state... [id=3544139]
github_repository.project_infrastructure: Refreshing state... [id=project-infrastructure]
github_repository.cactusref: Refreshing state... [id=cactusref]
github_organization_webhook.discord: Refreshing state... [id=198671336]
github_branch_default.mruby: Refreshing state... [id=mruby]
github_branch_default.spec: Refreshing state... [id=spec]
github_branch_default.mspec: Refreshing state... [id=mspec]
github_actions_organization_secret.dockerhub_user: Refreshing state... [id=DOCKERHUB_USER]
github_actions_organization_secret.dockerhub_token: Refreshing state... [id=DOCKERHUB_TOKEN]
github_branch_default.rust_onig: Refreshing state... [id=rust-onig]
github_branch_default.ruby: Refreshing state... [id=ruby]
module.team_cratesio_publishers.github_team_membership.admins["lopopolo"]: Refreshing state... [id=4053636:lopopolo]
module.team_ci.github_team_membership.members["artichoke-ci"]: Refreshing state... [id=3544139:artichoke-ci]
module.team_ci.github_team_membership.admins["lopopolo"]: Refreshing state... [id=3544139:lopopolo]
github_actions_organization_secret.terraform_aws_secret_key: Refreshing state... [id=TF_AWS_SECRET_KEY]
github_actions_organization_secret.terraform_aws_access_key: Refreshing state... [id=TF_AWS_ACCESS_KEY]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

Outputs:

github_actions_workflows_audit_pull_requests = <<EOT
Pull Requests:
none

EOT
ruby_version_pull_requests = <<EOT

Pull Requests:
none


EOT
```