### PR TITLE
Remove AWS access keys from GitHub organization secrets

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,8 +24,9 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@master
         with:
-          role-to-assume: arn:aws:iam::447522982029:role/github-actions-artichoke-project-infrastructure-role
           aws-region: us-west-2
+          role-to-assume: arn:aws:iam::447522982029:role/github-actions-artichoke-project-infrastructure-role
+          role-session-name: GitHubActionsSession@ci-terraform
 
       - name: Show AWS caller identity
         run: aws sts get-caller-identity

--- a/.github/workflows/tfsec.yaml
+++ b/.github/workflows/tfsec.yaml
@@ -12,6 +12,9 @@ name: tfsec
 jobs:
   terraform:
     name: Audit Terraform Infrastructure as Code
+    permissions:
+      id-token: write
+      contents: read
     runs-on: ubuntu-latest
 
     steps:
@@ -19,11 +22,14 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@master
         with:
-          aws-access-key-id: ${{ secrets.TF_AWS_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.TF_AWS_SECRET_KEY }}
           aws-region: us-west-2
+          role-to-assume: arn:aws:iam::447522982029:role/github-actions-artichoke-project-infrastructure-role
+          role-session-name: GitHubActionsSession@tfsec-terraform
+
+      - name: Show AWS caller identity
+        run: aws sts get-caller-identity
 
       - name: "Setup Terraform"
         uses: hashicorp/setup-terraform@v1

--- a/github/organization-secrets.tf
+++ b/github/organization-secrets.tf
@@ -1,15 +1,3 @@
-data "terraform_remote_state" "aws" {
-  backend = "s3"
-
-  config = {
-    bucket         = "artichoke-forge-project-infrastructure-terraform-state"
-    region         = "us-west-2"
-    key            = "aws/terraform.tfstate"
-    encrypt        = true
-    dynamodb_table = "terraform_statelock"
-  }
-}
-
 variable "dockerhub_token" {
   type      = string
   sensitive = true
@@ -18,22 +6,6 @@ variable "dockerhub_token" {
 variable "dockerhub_user" {
   type      = string
   sensitive = true
-}
-
-resource "github_actions_organization_secret" "terraform_aws_access_key" {
-  secret_name     = "TF_AWS_ACCESS_KEY"
-  visibility      = "selected"
-  plaintext_value = data.terraform_remote_state.aws.outputs.github_actions_iam_access_ids["project-infrastructure"]
-
-  selected_repository_ids = [github_repository.project_infrastructure.repo_id]
-}
-
-resource "github_actions_organization_secret" "terraform_aws_secret_key" {
-  secret_name     = "TF_AWS_SECRET_KEY"
-  visibility      = "selected"
-  plaintext_value = data.terraform_remote_state.aws.outputs.github_actions_iam_secret_keys["project-infrastructure"]
-
-  selected_repository_ids = [github_repository.project_infrastructure.repo_id]
 }
 
 resource "github_actions_organization_secret" "dockerhub_token" {


### PR DESCRIPTION
Update the `tfsec` workflow to assume the same role the CI workflow does. Use role session name to disambiguate each.

Followup to:

- #155