### PR TITLE
Update GitHub Actions OpenID Connect provider thumbprint

### DIFF
--- a/aws/modules/repository-assume-role/iam.tf
+++ b/aws/modules/repository-assume-role/iam.tf
@@ -10,7 +10,7 @@ resource "aws_iam_openid_connect_provider" "github" {
    "sts.amazonaws.com"
  ]
 
- thumbprint_list = ["a031c46782e6e6c662c2c87c76da9aa62ccabd8e"]
+ thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1"]
 }
 
 data "aws_iam_policy_document" "github_allow" {


### PR DESCRIPTION
https://github.blog/changelog/2022-01-13-github-actions-update-on-oidc-based-deployments-to-aws/

https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc_verify-thumbprint.html

Got alerted to this change by a scheduled CI run failure: https://github.com/artichoke/project-infrastructure/runs/4847357024?check_suite_focus=true