### PR TITLE
Fix `github-actions-s3-bucket-read-only-access` usage example

### DIFF
--- a/modules/github-actions-s3-bucket-read-only-access/README.md
+++ b/modules/github-actions-s3-bucket-read-only-access/README.md
@@ -8,7 +8,7 @@ access to an S3 bucket.
 
 ```terraform
 module "github_actions_project_infrastructure_assume_role" {
-  source = "../modules/aws/github-actions-s3-bucket-read-only-access"
+  source = "../modules/github-actions-s3-bucket-read-only-access"
 
   github_organization = "artichoke"
   github_repository   = "project-infrastructure"


### PR DESCRIPTION
This was missed in #190.