### PR TITLE
Refactor GitHub code for pushing branches with file updates

### DIFF
--- a/github/files/ruby-version.tpl
+++ b/github/files/ruby-version.tpl
@@ -1,1 +1,0 @@
-${ruby_version}

--- a/github/github-actions-workflow-audit.tf
+++ b/github/github-actions-workflow-audit.tf
@@ -113,8 +113,8 @@ data "template_file" "audit_workflow_ruby_rust" {
   template = file("${path.module}/templates/audit-workflow-ruby-rust.yaml")
 
   vars = {
-    // https://github.com/EmbarkStudios/cargo-deny/releases/tag/0.10.1
-    cargo_deny_version = "0.10.1"
+    // https://github.com/EmbarkStudios/cargo-deny/releases/tag/0.11.2
+    cargo_deny_version = "0.11.2"
     release_base_url   = "https://github.com/EmbarkStudios/cargo-deny/releases/download"
   }
 }

--- a/github/github-actions-workflow-audit.tf
+++ b/github/github-actions-workflow-audit.tf
@@ -74,7 +74,7 @@ module "audit_workflow_ruby" {
   file_contents = file("${path.module}/templates/audit-workflow-ruby.yaml")
 }
 
-output "audit_workflow_node_ruby_branches" {
+output "audit_workflow_ruby_branches" {
   value = <<-HREFS
 
   ## Branch URLs:

--- a/github/github-actions-workflow-audit.tf
+++ b/github/github-actions-workflow-audit.tf
@@ -2,7 +2,7 @@ locals {
   // Set `force_bump_...` to true to create branches for PRs that update the
   // Audit workflow organization-wide.
 
-  force_bump_audit_node = false
+  force_bump_audit_node = true
   audit_node_repos = [
     "clang-format",          // https://github.com/artichoke/clang-format
     "jasper",                // https://github.com/artichoke/jasper
@@ -10,20 +10,20 @@ locals {
     "www.artichokeruby.org", // https://github.com/artichoke/www.artichokeruby.org
   ]
 
-  force_bump_audit_ruby = false
+  force_bump_audit_ruby = true
   audit_ruby_repos = [
     "docker-artichoke-nightly", // https://github.com/artichoke/docker-artichoke-nightly
     "nightly",                  // https://github.com/artichoke/nightly
     "project-infrastructure",   // https://github.com/artichoke/project-infrastructure
   ]
 
-  force_bump_audit_node_ruby = false
+  force_bump_audit_node_ruby = true
   audit_node_ruby_repos = [
     "artichoke.github.io", // https://github.com/artichoke/artichoke.github.io
     "rubyconf",            // https://github.com/artichoke/rubyconf
   ]
 
-  force_bump_audit_ruby_rust = false
+  force_bump_audit_ruby_rust = true
   audit_ruby_rust_repos = [
     "artichoke",             // https://github.com/artichoke/artichoke
     "boba",                  // https://github.com/artichoke/boba
@@ -37,7 +37,7 @@ locals {
     "strudel",               // https://github.com/artichoke/strudel
   ]
 
-  force_bump_audit_node_ruby_rust = false
+  force_bump_audit_node_ruby_rust = true
   audit_node_ruby_rust_repos = [
     "playground", // https://github.com/artichoke/playground
   ]

--- a/github/github-actions-workflow-audit.tf
+++ b/github/github-actions-workflow-audit.tf
@@ -2,29 +2,29 @@ locals {
   // Set `force_bump_...` to true to create branches for PRs that update the
   // Audit workflow organization-wide.
 
-  force_bump_audit_node = false
-  audit_node_repos      = [
+  force_bump_audit_node = true
+  audit_node_repos = [
     "clang-format",          // https://github.com/artichoke/clang-format
     "jasper",                // https://github.com/artichoke/jasper
     "logo",                  // https://github.com/artichoke/logo
     "www.artichokeruby.org", // https://github.com/artichoke/www.artichokeruby.org
   ]
 
-  force_bump_audit_ruby = false
-  audit_ruby_repos      = [
+  force_bump_audit_ruby = true
+  audit_ruby_repos = [
     "docker-artichoke-nightly", // https://github.com/artichoke/docker-artichoke-nightly
     "nightly",                  // https://github.com/artichoke/nightly
     "project-infrastructure",   // https://github.com/artichoke/project-infrastructure
   ]
 
-  force_bump_audit_node_ruby = false
-  audit_node_ruby_repos      = [
+  force_bump_audit_node_ruby = true
+  audit_node_ruby_repos = [
     "artichoke.github.io", // https://github.com/artichoke/artichoke.github.io
     "rubyconf",            // https://github.com/artichoke/rubyconf
   ]
 
-  force_bump_audit_ruby_rust = false
-  audit_ruby_rust_repos      = [
+  force_bump_audit_ruby_rust = true
+  audit_ruby_rust_repos = [
     "artichoke",             // https://github.com/artichoke/artichoke
     "boba",                  // https://github.com/artichoke/boba
     "cactusref",             // https://github.com/artichoke/cactusref
@@ -37,9 +37,9 @@ locals {
     "strudel",               // https://github.com/artichoke/strudel
   ]
 
-  force_bump_audit_node_ruby_rust = false
-  audit_node_ruby_rust_repos      = [
-    "playground",            // https://github.com/artichoke/playground
+  force_bump_audit_node_ruby_rust = true
+  audit_node_ruby_rust_repos = [
+    "playground", // https://github.com/artichoke/playground
   ]
 }
 

--- a/github/github-actions-workflow-audit.tf
+++ b/github/github-actions-workflow-audit.tf
@@ -10,7 +10,7 @@ locals {
     "www.artichokeruby.org", // https://github.com/artichoke/www.artichokeruby.org
   ]
 
-  force_bump_audit_ruby = false
+  force_bump_audit_ruby = true
   audit_ruby_repos = [
     "docker-artichoke-nightly", // https://github.com/artichoke/docker-artichoke-nightly
     "nightly",                  // https://github.com/artichoke/nightly

--- a/github/github-actions-workflow-audit.tf
+++ b/github/github-actions-workflow-audit.tf
@@ -1,162 +1,143 @@
 locals {
-  // Set `force_bump` to true to create branches for PRs that update the Audit
-  // workflow organization-wide.
-  force_bump = false
+  // Set `force_bump_...` to true to create branches for PRs that update the
+  // Audit workflow organization-wide.
 
-  // https://github.com/EmbarkStudios/cargo-deny/releases/tag/0.10.1
-  cargo_deny_version = "0.10.1"
-  cargo_deny_audit_repos = {
-    artichoke             = "artichoke"             // https://github.com/artichoke/artichoke
-    boba                  = "boba"                  // https://github.com/artichoke/boba
-    cactusref             = "cactusref"             // https://github.com/artichoke/cactusref
-    focaccia              = "focaccia"              // https://github.com/artichoke/focaccia
-    intaglio              = "intaglio"              // https://github.com/artichoke/intaglio
-    playground            = "playground"            // https://github.com/artichoke/playground
-    rand_mt               = "rand_mt"               // https://github.com/artichoke/rand_mt
-    raw_parts             = "raw-parts"             // https://github.com/artichoke/raw-parts
-    roe                   = "roe"                   // https://github.com/artichoke/roe
-    ruby_file_expand_path = "ruby-file-expand-path" // https://github.com/artichoke/ruby-file-expand-path
-    strudel               = "strudel"               // https://github.com/artichoke/strudel
-  }
+  force_bump_audit_node = false
+  audit_node_repos      = [
+    "clang-format",          // https://github.com/artichoke/clang-format
+    "jasper",                // https://github.com/artichoke/jasper
+    "logo",                  // https://github.com/artichoke/logo
+    "www.artichokeruby.org", // https://github.com/artichoke/www.artichokeruby.org
+  ]
 
-  npm_audit_repos = {
-    artichoke_github_io   = "artichoke.github.io"   // https://github.com/artichoke/artichoke.github.io
-    clang_format          = "clang-format"          // https://github.com/artichoke/clang-format
-    jasper                = "jasper"                // https://github.com/artichoke/jasper
-    logo                  = "logo"                  // https://github.com/artichoke/logo
-    playground            = "playground"            // https://github.com/artichoke/playground
-    rubyconf              = "rubyconf"              // https://github.com/artichoke/rubyconf
-    www_artichokeruby_org = "www.artichokeruby.org" // https://github.com/artichoke/www.artichokeruby.org
-  }
+  force_bump_audit_ruby = false
+  audit_ruby_repos      = [
+    "docker-artichoke-nightly", // https://github.com/artichoke/docker-artichoke-nightly
+    "nightly",                  // https://github.com/artichoke/nightly
+    "project-infrastructure",   // https://github.com/artichoke/project-infrastructure
+  ]
 
-  bundler_audit_repos = {
-    artichoke                = "artichoke"                // https://github.com/artichoke/artichoke
-    artichoke_github_io      = "artichoke.github.io"      // https://github.com/artichoke/artichoke.github.io
-    boba                     = "boba"                     // https://github.com/artichoke/boba
-    cactusref                = "cactusref"                // https://github.com/artichoke/cactusref
-    docker_artichoke_nightly = "docker-artichoke-nightly" // https://github.com/artichoke/docker-artichoke-nightly
-    focaccia                 = "focaccia"                 // https://github.com/artichoke/focaccia
-    intaglio                 = "intaglio"                 // https://github.com/artichoke/intaglio
-    nightly                  = "nightly"                  // https://github.com/artichoke/nightly
-    playground               = "playground"               // https://github.com/artichoke/playground
-    project_infrastructure   = "project-infrastructure"   // https://github.com/artichoke/project-infrastructure
-    rand_mt                  = "rand_mt"                  // https://github.com/artichoke/rand_mt
-    raw_parts                = "raw-parts"                // https://github.com/artichoke/raw-parts
-    roe                      = "roe"                      // https://github.com/artichoke/roe
-    rubyconf                 = "rubyconf"                 // https://github.com/artichoke/rubyconf
-    ruby_file_expand_path    = "ruby-file-expand-path"    // https://github.com/artichoke/ruby-file-expand-path
-    strudel                  = "strudel"                  // https://github.com/artichoke/strudel
-  }
+  force_bump_audit_node_ruby = false
+  audit_node_ruby_repos      = [
+    "artichoke.github.io", // https://github.com/artichoke/artichoke.github.io
+    "playground",          // https://github.com/artichoke/playground
+    "rubyconf",            // https://github.com/artichoke/rubyconf
+  ]
 
-  audit_managed_repos = {
-    artichoke                = "artichoke"                // https://github.com/artichoke/artichoke
-    artichoke_github_io      = "artichoke.github.io"      // https://github.com/artichoke/artichoke.github.io
-    boba                     = "boba"                     // https://github.com/artichoke/boba
-    cactusref                = "cactusref"                // https://github.com/artichoke/cactusref
-    clang_format             = "clang-format"             // https://github.com/artichoke/clang-format
-    docker_artichoke_nightly = "docker-artichoke-nightly" // https://github.com/artichoke/docker-artichoke-nightly
-    focaccia                 = "focaccia"                 // https://github.com/artichoke/focaccia
-    intaglio                 = "intaglio"                 // https://github.com/artichoke/intaglio
-    jasper                   = "jasper"                   // https://github.com/artichoke/jasper
-    logo                     = "logo"                     // https://github.com/artichoke/logo
-    nightly                  = "nightly"                  // https://github.com/artichoke/nightly
-    playground               = "playground"               // https://github.com/artichoke/playground
-    project_infrastructure   = "project-infrastructure"   // https://github.com/artichoke/project-infrastructure
-    rand_mt                  = "rand_mt"                  // https://github.com/artichoke/rand_mt
-    raw_parts                = "raw-parts"                // https://github.com/artichoke/raw-parts
-    roe                      = "roe"                      // https://github.com/artichoke/roe
-    rubyconf                 = "rubyconf"                 // https://github.com/artichoke/rubyconf
-    ruby_file_expand_path    = "ruby-file-expand-path"    // https://github.com/artichoke/ruby-file-expand-path
-    strudel                  = "strudel"                  // https://github.com/artichoke/strudel
-    www_artichokeruby_org    = "www.artichokeruby.org"    // https://github.com/artichoke/www.artichokeruby.org
-  }
-}
-
-data "template_file" "github_actions_workflows_audit" {
-  for_each = local.audit_managed_repos
-
-  template = file("${path.module}/files/workflows/audit.yaml.tpl")
-  vars = {
-    cargo_deny_version = local.cargo_deny_version
-    has_cargo_deny     = lookup(local.cargo_deny_audit_repos, each.key, "n/a") == each.value
-    has_npm_audit      = lookup(local.npm_audit_repos, each.key, "n/a") == each.value
-    has_bundler_audit  = lookup(local.bundler_audit_repos, each.key, "n/a") == each.value
-  }
-}
-
-data "github_branch" "github_actions_workflows_audit_base" {
-  for_each = local.audit_managed_repos
-
-  repository = each.value
-  branch     = "trunk"
-
-  depends_on = [
-    github_repository.artichoke,
-    github_repository.artichoke_github_io,
-    github_repository.boba,
-    github_repository.cactusref,
-    github_repository.clang_format,
-    github_repository.docker_artichoke_nightly,
-    github_repository.focaccia,
-    github_repository.intaglio,
-    github_repository.jasper,
-    github_repository.logo,
-    github_repository.nightly,
-    github_repository.playground,
-    github_repository.project_infrastructure,
-    github_repository.rand_mt,
-    github_repository.raw_parts,
-    github_repository.roe,
-    github_repository.rubyconf,
-    github_repository.ruby_file_expand_path,
-    github_repository.strudel,
-    github_repository.www_artichokeruby_org,
+  force_bump_audit_ruby_rust = false
+  audit_ruby_rust_repos      = [
+    "artichoke",             // https://github.com/artichoke/artichoke
+    "boba",                  // https://github.com/artichoke/boba
+    "cactusref",             // https://github.com/artichoke/cactusref
+    "focaccia",              // https://github.com/artichoke/focaccia
+    "intaglio",              // https://github.com/artichoke/intaglio
+    "playground",            // https://github.com/artichoke/playground
+    "rand_mt",               // https://github.com/artichoke/rand_mt
+    "raw-parts",             // https://github.com/artichoke/raw-parts
+    "roe",                   // https://github.com/artichoke/roe
+    "ruby-file-expand-path", // https://github.com/artichoke/ruby-file-expand-path
+    "strudel",               // https://github.com/artichoke/strudel
   ]
 }
 
-resource "github_branch" "github_actions_workflows_audit" {
-  for_each = local.force_bump ? local.audit_managed_repos : {}
+module "audit_workflow_node" {
+  source   = "../modules/update-github-repository-file"
+  for_each = local.force_bump_audit_node_ruby ? toset(local.audit_node_repos) : toset([])
 
+  organization  = "artichoke"
   repository    = each.value
-  branch        = "terraform/github_actions_workflows_audit"
-  source_branch = "trunk"
-  source_sha    = data.github_branch.github_actions_workflows_audit_base[each.key].sha
+  base_branch   = "trunk"
+  file_path     = ".github/workflows/audit.yaml"
+  file_contents = file("${path.module}/templates/audit-workflow-node.yaml")
 }
 
-resource "github_repository_file" "github_actions_workflows_audit" {
-  for_each = local.force_bump ? local.audit_managed_repos : {}
+output "audit_workflow_node_branches" {
+  value = <<-HREFS
 
-  repository          = each.value
-  branch              = github_branch.github_actions_workflows_audit[each.key].ref
-  file                = ".github/workflows/audit.yaml"
-  content             = data.template_file.github_actions_workflows_audit[each.key].rendered
-  commit_message      = <<-MESSAGE
-    Update Audit GitHub Actions workflow
+  ## Branch URLs:
 
-    Managed by Terraform.
-
-    The cargo-deny version is ${local.cargo_deny_version}.
-  MESSAGE
-  commit_author       = "artichoke-ci"
-  commit_email        = "ci@artichokeruby.org"
-  overwrite_on_create = true
-}
-
-output "github_actions_workflows_audit_pull_requests" {
-  value = <<-CONFIG
-    Pull Requests:
-    ${local.force_bump ? join(
+  ${join(
   "\n",
-  formatlist(
-    "%s",
-    [for slug, repo in local.audit_managed_repos :
-      join("/", [
-        "https://github.com/artichoke",
-        repo,
-        "tree",
-        "terraform/github_actions_workflows_audit",
-      ])
-    ]
-)) : "none"}
-  CONFIG
+  formatlist("- %s", [for repo, audit_workflow in module.audit_workflow_node : audit_workflow.branch_href])
+)}
+  HREFS
+}
+
+module "audit_workflow_ruby" {
+  source   = "../modules/update-github-repository-file"
+  for_each = local.force_bump_audit_ruby ? toset(local.audit_ruby_repos) : toset([])
+
+  organization  = "artichoke"
+  repository    = each.value
+  base_branch   = "trunk"
+  file_path     = ".github/workflows/audit.yaml"
+  file_contents = file("${path.module}/templates/audit-workflow-ruby.yaml")
+}
+
+output "audit_workflow_node_ruby_branches" {
+  value = <<-HREFS
+
+  ## Branch URLs:
+
+  ${join(
+  "\n",
+  formatlist("- %s", [for repo, audit_workflow in module.audit_workflow_ruby : audit_workflow.branch_href])
+)}
+  HREFS
+}
+
+module "audit_workflow_node_ruby" {
+  source   = "../modules/update-github-repository-file"
+  for_each = local.force_bump_audit_node_ruby ? toset(local.audit_node_ruby_repos) : toset([])
+
+  organization  = "artichoke"
+  repository    = each.value
+  base_branch   = "trunk"
+  file_path     = ".github/workflows/audit.yaml"
+  file_contents = file("${path.module}/templates/audit-workflow-node-ruby.yaml")
+}
+
+output "audit_workflow_node_ruby_branches" {
+  value = <<-HREFS
+
+  ## Branch URLs:
+
+  ${join(
+  "\n",
+  formatlist("- %s", [for repo, audit_workflow in module.audit_workflow_node_ruby : audit_workflow.branch_href])
+)}
+  HREFS
+}
+
+data "template_file" "audit_workflow_ruby_rust" {
+  template = file("${path.module}/templates/audit-workflow-ruby-rust.yaml")
+
+  vars = {
+    // https://github.com/EmbarkStudios/cargo-deny/releases/tag/0.10.1
+    cargo_deny_version = "0.10.1"
+    release_base_url   = "https://github.com/EmbarkStudios/cargo-deny/releases/download"
+  }
+}
+
+module "audit_workflow_ruby_rust" {
+  source   = "../modules/update-github-repository-file"
+  for_each = local.force_bump_audit_ruby_rust ? toset(local.audit_ruby_rust_repos) : toset([])
+
+  organization  = "artichoke"
+  repository    = each.value
+  base_branch   = "trunk"
+  file_path     = ".github/workflows/audit.yaml"
+  file_contents = data.template_file.audit_workflow_ruby_rust.rendered
+}
+
+output "audit_workflow_ruby_rust_branches" {
+  value = <<-HREFS
+
+  ## Branch URLs:
+
+  ${join(
+  "\n",
+  formatlist("- %s", [for repo, audit_workflow in module.audit_workflow_ruby_rust : audit_workflow.branch_href])
+)}
+  HREFS
 }

--- a/github/github-actions-workflow-audit.tf
+++ b/github/github-actions-workflow-audit.tf
@@ -2,7 +2,7 @@ locals {
   // Set `force_bump_...` to true to create branches for PRs that update the
   // Audit workflow organization-wide.
 
-  force_bump_audit_node = true
+  force_bump_audit_node = false
   audit_node_repos = [
     "clang-format",          // https://github.com/artichoke/clang-format
     "jasper",                // https://github.com/artichoke/jasper
@@ -10,20 +10,20 @@ locals {
     "www.artichokeruby.org", // https://github.com/artichoke/www.artichokeruby.org
   ]
 
-  force_bump_audit_ruby = true
+  force_bump_audit_ruby = false
   audit_ruby_repos = [
     "docker-artichoke-nightly", // https://github.com/artichoke/docker-artichoke-nightly
     "nightly",                  // https://github.com/artichoke/nightly
     "project-infrastructure",   // https://github.com/artichoke/project-infrastructure
   ]
 
-  force_bump_audit_node_ruby = true
+  force_bump_audit_node_ruby = false
   audit_node_ruby_repos = [
     "artichoke.github.io", // https://github.com/artichoke/artichoke.github.io
     "rubyconf",            // https://github.com/artichoke/rubyconf
   ]
 
-  force_bump_audit_ruby_rust = true
+  force_bump_audit_ruby_rust = false
   audit_ruby_rust_repos = [
     "artichoke",             // https://github.com/artichoke/artichoke
     "boba",                  // https://github.com/artichoke/boba
@@ -37,7 +37,7 @@ locals {
     "strudel",               // https://github.com/artichoke/strudel
   ]
 
-  force_bump_audit_node_ruby_rust = true
+  force_bump_audit_node_ruby_rust = false
   audit_node_ruby_rust_repos = [
     "playground", // https://github.com/artichoke/playground
   ]

--- a/github/github-actions-workflow-audit.tf
+++ b/github/github-actions-workflow-audit.tf
@@ -10,7 +10,7 @@ locals {
     "www.artichokeruby.org", // https://github.com/artichoke/www.artichokeruby.org
   ]
 
-  force_bump_audit_ruby = true
+  force_bump_audit_ruby = false
   audit_ruby_repos = [
     "docker-artichoke-nightly", // https://github.com/artichoke/docker-artichoke-nightly
     "nightly",                  // https://github.com/artichoke/nightly

--- a/github/ruby-version.tf
+++ b/github/ruby-version.tf
@@ -1,5 +1,5 @@
 locals {
-  ruby_version_force_bump = false
+  force_bump_ruby_version = false
 
   // https://github.com/ruby/ruby/tree/v3_1_0
   ruby_version = "3.1.0"
@@ -29,7 +29,7 @@ locals {
 
 module "ruby_version" {
   source   = "../modules/update-github-repository-file"
-  for_each = local.ruby_version_force_bump ? toset(local.ruby_version_repos) : toset([])
+  for_each = local.force_bump_ruby_version ? toset(local.ruby_version_repos) : toset([])
 
   organization  = "artichoke"
   repository    = each.value

--- a/github/ruby-version.tf
+++ b/github/ruby-version.tf
@@ -1,11 +1,11 @@
 locals {
-  ruby_version_force_bump = false
+  ruby_version_force_bump = true
 
-  // https://github.com/ruby/ruby/tree/v3_0_2
-  ruby_version = "3.0.2"
+  // https://github.com/ruby/ruby/tree/v3_1_0
+  ruby_version = "3.1.0"
 
   ruby_version_repos = [
-    "artichoke",                // https://github.com/artichoke/artichoke
+    // "artichoke",                // https://github.com/artichoke/artichoke
     "artichoke.github.io",      // https://github.com/artichoke/artichoke.github.io
     "boba",                     // https://github.com/artichoke/boba
     "cactusref",                // https://github.com/artichoke/cactusref

--- a/github/ruby-version.tf
+++ b/github/ruby-version.tf
@@ -1,11 +1,14 @@
 locals {
-  ruby_version_force_bump = true
+  ruby_version_force_bump = false
 
   // https://github.com/ruby/ruby/tree/v3_1_0
   ruby_version = "3.1.0"
 
   ruby_version_repos = [
-    // "artichoke",                // https://github.com/artichoke/artichoke
+    // Artichoke's `.ruby-version` file is not managed with Terraform because
+    // Ruby version upgrade require extra (and manual) care.
+    //
+    // "artichoke",             // https://github.com/artichoke/artichoke
     "artichoke.github.io",      // https://github.com/artichoke/artichoke.github.io
     "boba",                     // https://github.com/artichoke/boba
     "cactusref",                // https://github.com/artichoke/cactusref

--- a/github/ruby-version.tf
+++ b/github/ruby-version.tf
@@ -40,6 +40,7 @@ module "ruby_version" {
 
 output "ruby_version_branches" {
   value = <<-HREFS
+
   ## Branch URLs:
 
   ${join(

--- a/github/ruby-version.tf
+++ b/github/ruby-version.tf
@@ -1,98 +1,47 @@
 locals {
-  // Set `ruby_version_force_bump` to true to create branches for PRs that
-  // update the `.ruby-version` version used in each repository.
   ruby_version_force_bump = false
+
   // https://github.com/ruby/ruby/tree/v3_0_2
   ruby_version = "3.0.2"
-  ruby_version_repos = {
-    artichoke                = "artichoke"                // https://github.com/artichoke/artichoke
-    artichoke_github_io      = "artichoke.github.io"      // https://github.com/artichoke/artichoke.github.io
-    boba                     = "boba"                     // https://github.com/artichoke/boba
-    cactusref                = "cactusref"                // https://github.com/artichoke/cactusref
-    docker_artichoke_nightly = "docker-artichoke-nightly" // https://github.com/artichoke/docker-artichoke-nightly
-    focaccia                 = "focaccia"                 // https://github.com/artichoke/focaccia
-    intaglio                 = "intaglio"                 // https://github.com/artichoke/intaglio
-    nightly                  = "nightly"                  // https://github.com/artichoke/nightly
-    playground               = "playground"               // https://github.com/artichoke/playground
-    project_infrastructure   = "project-infrastructure"   // https://github.com/artichoke/project-infrastructure
-    rand_mt                  = "rand_mt"                  // https://github.com/artichoke/rand_mt
-    raw_parts                = "raw-parts"                // https://github.com/artichoke/raw-parts
-    roe                      = "roe"                      // https://github.com/artichoke/roe
-    rubyconf                 = "rubyconf"                 // https://github.com/artichoke/rubyconf
-    ruby_file_expand_path    = "ruby-file-expand-path"    // https://github.com/artichoke/ruby-file-expand-path
-    strudel                  = "strudel"                  // https://github.com/artichoke/strudel
-  }
-}
 
-data "template_file" "ruby_version" {
-  template = file("${path.module}/files/ruby-version.tpl")
-  vars = {
-    ruby_version = local.ruby_version
-  }
-}
-
-data "github_branch" "ruby_version_sync_base" {
-  for_each = local.ruby_version_repos
-
-  repository = each.value
-  branch     = "trunk"
-
-  depends_on = [
-    github_repository.artichoke,
-    github_repository.artichoke_github_io,
-    github_repository.boba,
-    github_repository.cactusref,
-    github_repository.focaccia,
-    github_repository.intaglio,
-    github_repository.playground,
-    github_repository.project_infrastructure,
-    github_repository.rand_mt,
-    github_repository.roe,
-    github_repository.rubyconf,
-    github_repository.ruby_file_expand_path,
-    github_repository.strudel,
+  ruby_version_repos = [
+    "artichoke",                // https://github.com/artichoke/artichoke
+    "artichoke.github.io",      // https://github.com/artichoke/artichoke.github.io
+    "boba",                     // https://github.com/artichoke/boba
+    "cactusref",                // https://github.com/artichoke/cactusref
+    "docker-artichoke-nightly", // https://github.com/artichoke/docker-artichoke-nightly
+    "focaccia",                 // https://github.com/artichoke/focaccia
+    "intaglio",                 // https://github.com/artichoke/intaglio
+    "nightly",                  // https://github.com/artichoke/nightly
+    "playground",               // https://github.com/artichoke/playground
+    "project-infrastructure",   // https://github.com/artichoke/project-infrastructure
+    "rand_mt",                  // https://github.com/artichoke/rand_mt
+    "raw-parts",                // https://github.com/artichoke/raw-parts
+    "roe",                      // https://github.com/artichoke/roe
+    "rubyconf",                 // https://github.com/artichoke/rubyconf
+    "ruby-file-expand-path",    // https://github.com/artichoke/ruby-file-expand-path
+    "strudel",                  // https://github.com/artichoke/strudel
   ]
 }
 
-resource "github_branch" "ruby_version" {
-  for_each = local.ruby_version_force_bump ? local.ruby_version_repos : {}
+module "ruby_version" {
+  source   = "../modules/update-github-repository-file"
+  for_each = local.ruby_version_force_bump ? toset(local.ruby_version_repos) : toset([])
 
+  organization  = "artichoke"
   repository    = each.value
-  branch        = "terraform/ruby_version_bump"
-  source_branch = "trunk"
-  source_sha    = data.github_branch.ruby_version_sync_base[each.key].sha
+  base_branch   = "trunk"
+  file_path     = ".ruby-version"
+  file_contents = "${local.ruby_version}\n"
 }
 
-resource "github_repository_file" "ruby_version" {
-  for_each = local.ruby_version_force_bump ? local.ruby_version_repos : {}
+output "ruby_version_branches" {
+  value = <<-HREFS
+  ## Branch URLs:
 
-  repository          = each.value
-  branch              = github_branch.ruby_version[each.key].ref
-  file                = ".ruby-version"
-  content             = data.template_file.ruby_version.rendered
-  commit_message      = "Update Ruby toolchain version to ${local.ruby_version} in .ruby-version\n\nManaged by Terraform"
-  commit_author       = "artichoke-ci"
-  commit_email        = "ci@artichokeruby.org"
-  overwrite_on_create = true
-}
-
-output "ruby_version_pull_requests" {
-  value = <<CONFIG
-
-Pull Requests:
-${local.ruby_version_force_bump ? join(
+  ${join(
   "\n",
-  formatlist(
-    "%s",
-    [for repo in keys(local.ruby_version_repos) :
-      join("/", [
-        "https://github.com/artichoke",
-        local.ruby_version_repos[repo],
-        "tree",
-        "terraform/ruby_version_bump",
-      ])
-    ]
-)) : "none"}
-
-CONFIG
+  formatlist("- %s", [for repo, ruby_version in module.ruby_version : ruby_version.branch_href])
+)}
+  HREFS
 }

--- a/github/templates/audit-workflow-node-ruby-rust.yaml
+++ b/github/templates/audit-workflow-node-ruby-rust.yaml
@@ -57,7 +57,10 @@ jobs:
           override: true
 
       - name: Generate Cargo.lock
-        run: if [[ ! -f "Cargo.lock" ]]; then; cargo generate-lockfile --verbose; fi
+        run: |
+          if [[ ! -f "Cargo.lock" ]]; then
+            cargo generate-lockfile --verbose
+          fi
 
       - name: Setup cargo-deny
         run: curl -sL "${release_base_url}/${cargo_deny_version}/cargo-deny-${cargo_deny_version}-x86_64-unknown-linux-musl.tar.gz" | sudo tar xvz -C /usr/local/bin/ --strip-components=1

--- a/github/templates/audit-workflow-node-ruby-rust.yaml
+++ b/github/templates/audit-workflow-node-ruby-rust.yaml
@@ -1,0 +1,69 @@
+---
+name: Audit
+"on":
+  push:
+    branches:
+      - trunk
+  pull_request:
+    branches:
+      - trunk
+  schedule:
+    - cron: "0 0 * * TUE"
+jobs:
+  js:
+    name: Audit JS Dependencies
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Nodejs toolchain
+        run: npm ci
+
+      - name: npm audit
+        run: npm audit
+
+  ruby:
+    name: Audit Ruby Dependencies
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Ruby toolchain
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ".ruby-version"
+          bundler-cache: true
+
+      - name: bundler-audit
+        run: bundle exec bundle-audit check --update
+
+  rust:
+    name: Audit Rust Dependencies
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+
+      - name: Generate Cargo.lock
+        run: if [[ ! -f "Cargo.lock" ]]; then; cargo generate-lockfile --verbose; fi
+
+      - name: Setup cargo-deny
+        run: curl -sL "${release_base_url}/${cargo_deny_version}/cargo-deny-${cargo_deny_version}-x86_64-unknown-linux-musl.tar.gz" | sudo tar xvz -C /usr/local/bin/ --strip-components=1
+
+      - name: Show cargo-deny version
+        run: cargo-deny --version
+
+      - name: Run cargo-deny
+        run: cargo-deny --locked check --show-stats

--- a/github/templates/audit-workflow-node-ruby.yaml
+++ b/github/templates/audit-workflow-node-ruby.yaml
@@ -1,0 +1,42 @@
+---
+name: Audit
+"on":
+  push:
+    branches:
+      - trunk
+  pull_request:
+    branches:
+      - trunk
+  schedule:
+    - cron: "0 0 * * TUE"
+jobs:
+  js:
+    name: Audit JS Dependencies
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Nodejs toolchain
+        run: npm ci
+
+      - name: npm audit
+        run: npm audit
+
+  ruby:
+    name: Audit Ruby Dependencies
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Ruby toolchain
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ".ruby-version"
+          bundler-cache: true
+
+      - name: bundler-audit
+        run: bundle exec bundle-audit check --update

--- a/github/templates/audit-workflow-node.yaml
+++ b/github/templates/audit-workflow-node.yaml
@@ -1,0 +1,25 @@
+---
+name: Audit
+"on":
+  push:
+    branches:
+      - trunk
+  pull_request:
+    branches:
+      - trunk
+  schedule:
+    - cron: "0 0 * * TUE"
+jobs:
+  js:
+    name: Audit JS Dependencies
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Nodejs toolchain
+        run: npm ci
+
+      - name: npm audit
+        run: npm audit

--- a/github/templates/audit-workflow-ruby-rust.yaml
+++ b/github/templates/audit-workflow-ruby-rust.yaml
@@ -10,24 +10,8 @@ name: Audit
   schedule:
     - cron: "0 0 * * TUE"
 jobs:
-  js:
-    name: Audit JS Dependencies
-    if: ${has_npm_audit}
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
-      - name: Install Nodejs toolchain
-        run: npm ci
-
-      - name: npm audit
-        run: npm audit
-
   ruby:
     name: Audit Ruby Dependencies
-    if: ${has_bundler_audit}
     runs-on: ubuntu-latest
 
     steps:
@@ -45,7 +29,6 @@ jobs:
 
   rust:
     name: Audit Rust Dependencies
-    if: ${has_cargo_deny}
     runs-on: ubuntu-latest
 
     steps:
@@ -55,25 +38,17 @@ jobs:
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: stable
           profile: minimal
           override: true
 
       - name: Generate Cargo.lock
-        run: |
-          if [[ ! -f "Cargo.lock" ]]; then
-            cargo generate-lockfile --verbose
-          fi
+        run: if [[ ! -f "Cargo.lock" ]]; then; cargo generate-lockfile --verbose; fi
 
       - name: Setup cargo-deny
-        run: |
-          release_base="https://github.com/EmbarkStudios/cargo-deny/releases/download"
-          version="${cargo_deny_version}"
-          cargo_deny_tarball="$release_base/$version/cargo-deny-$version-x86_64-unknown-linux-musl.tar.gz"
-          echo "Downloading cargo-deny $version from $cargo_deny_tarball."
-          curl -sL "$cargo_deny_tarball" | sudo tar xvz -C /usr/local/bin/ --strip-components=1
+        run: curl -sL "${release_base_url}/${cargo_deny_version}/cargo-deny-${cargo_deny_version}-x86_64-unknown-linux-musl.tar.gz" | sudo tar xvz -C /usr/local/bin/ --strip-components=1
 
-      - name: cargo-deny version
+      - name: Show cargo-deny version
         run: cargo-deny --version
 
       - name: Run cargo-deny

--- a/github/templates/audit-workflow-ruby-rust.yaml
+++ b/github/templates/audit-workflow-ruby-rust.yaml
@@ -43,7 +43,10 @@ jobs:
           override: true
 
       - name: Generate Cargo.lock
-        run: if [[ ! -f "Cargo.lock" ]]; then; cargo generate-lockfile --verbose; fi
+        run: |
+          if [[ ! -f "Cargo.lock" ]]; then
+            cargo generate-lockfile --verbose
+          fi
 
       - name: Setup cargo-deny
         run: curl -sL "${release_base_url}/${cargo_deny_version}/cargo-deny-${cargo_deny_version}-x86_64-unknown-linux-musl.tar.gz" | sudo tar xvz -C /usr/local/bin/ --strip-components=1

--- a/github/templates/audit-workflow-ruby.yaml
+++ b/github/templates/audit-workflow-ruby.yaml
@@ -12,7 +12,6 @@ name: Audit
 jobs:
   ruby:
     name: Audit Ruby Dependencies
-    if: ${has_bundler_audit}
     runs-on: ubuntu-latest
 
     steps:

--- a/github/templates/audit-workflow-ruby.yaml
+++ b/github/templates/audit-workflow-ruby.yaml
@@ -1,0 +1,29 @@
+---
+name: Audit
+"on":
+  push:
+    branches:
+      - trunk
+  pull_request:
+    branches:
+      - trunk
+  schedule:
+    - cron: "0 0 * * TUE"
+jobs:
+  ruby:
+    name: Audit Ruby Dependencies
+    if: ${has_bundler_audit}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Ruby toolchain
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ".ruby-version"
+          bundler-cache: true
+
+      - name: bundler-audit
+        run: bundle exec bundle-audit check --update

--- a/modules/update-github-repository-file/README.md
+++ b/modules/update-github-repository-file/README.md
@@ -1,0 +1,45 @@
+# Update GitHub Repository File
+
+This folder contains a Terraform module to write contents to a file in a
+repository on GitHub. This module creates these changes on a new branch that may
+be opened as a pull request.
+
+## Usage
+
+```terraform
+module "ruby_version" {
+  source   = "../modules/update-github-repository-file"
+  for_each = toset([
+    "artichoke",
+    "playground",
+    "project-infrastructure",
+  ])
+
+  organization  = "artichoke"
+  repository    = each.value
+  base_branch   = "trunk"
+  file_path     = ".ruby-version"
+  file_contents = "3.1.0\n"
+}
+```
+
+## Parameters
+
+- `organization`: The name of the GitHub organization that the target repository
+  is a part of. For example, in
+  <https://github.com/artichoke/project-infrastructure>, the GitHub organization
+  is `artichoke`. This parameter defaults to `artichoke`.
+- `repository`: The name of the repository to which this module will push the
+  file contents. For example, in
+  <https://github.com/artichoke/project-infrastructure>, the GitHub repository
+  is `project-infrastructure`.
+- `base_branch`: The git branch in the target repository to base the changes
+  from. This parameter defaults to `trunk`.
+- `file_path`: The file path to push the contents to. This is a relative path
+  from the target repository root.
+- `file_contents`: The raw file content to be written at `file_path`.
+
+## Outputs
+
+- `branch_href`: A URL to the newly-pushed branch on GitHub, from which a PR may
+  be opened.

--- a/modules/update-github-repository-file/main.tf
+++ b/modules/update-github-repository-file/main.tf
@@ -32,7 +32,7 @@ resource "github_repository_file" "file" {
   ## Contents
 
   ```
-  ${var.file_contents}
+  ${chomp(var.file_contents)}
   ```
   MESSAGE
 

--- a/modules/update-github-repository-file/main.tf
+++ b/modules/update-github-repository-file/main.tf
@@ -1,0 +1,42 @@
+terraform {
+  required_providers {
+    github = {
+      source  = "integrations/github"
+      version = "~> 4.20"
+    }
+  }
+}
+
+data "github_branch" "base" {
+  repository = var.repository
+  branch     = var.base_branch
+}
+
+resource "github_branch" "pr_target" {
+  repository = var.repository
+  branch     = "terraform/update-file-${replace(var.file_path, "/[ \\/]/", "-")}"
+  source_sha = data.github_branch.base.sha
+}
+
+resource "github_repository_file" "file" {
+  repository = var.repository
+  branch     = github_branch.pr_target.ref
+  file       = var.file_path
+  content    = var.file_contents
+
+  commit_message = <<-MESSAGE
+  chore: Update `${var.file_path}` in `${var.organization}/${var.repository}`
+
+  Managed by Terraform.
+
+  ## Contents
+
+  ```
+  ${var.file_contents}
+  ```
+  MESSAGE
+
+  commit_author       = "artichoke-ci"
+  commit_email        = "ci@artichokeruby.org"
+  overwrite_on_create = true
+}

--- a/modules/update-github-repository-file/outputs.tf
+++ b/modules/update-github-repository-file/outputs.tf
@@ -1,0 +1,10 @@
+output "branch_href" {
+  description = "Link to the newly-created branch"
+  value = join("/", [
+    "https://github.com/",
+    var.organization,
+    var.repository,
+    "tree",
+    replace(github_branch.pr_target.ref, "refs/heads/", ""),
+  ])
+}

--- a/modules/update-github-repository-file/variables.tf
+++ b/modules/update-github-repository-file/variables.tf
@@ -1,0 +1,26 @@
+variable "organization" {
+  description = "Organization on GitHub, defaults to `artichoke`"
+  default     = "artichoke"
+  type        = string
+}
+
+variable "repository" {
+  description = "Git repository on GitHub"
+  type        = string
+}
+
+variable "base_branch" {
+  description = "Branch to base the pull request from, defaults to `trunk`"
+  default     = "trunk"
+  type        = string
+}
+
+variable "file_path" {
+  description = "Path for the file to update in the given repository, relative to the repository root"
+  type        = string
+}
+
+variable "file_contents" {
+  description = "Content to write at the given file path"
+  type        = string
+}


### PR DESCRIPTION
Create a new terraform module `update-github-repository-file` which takes a repo, filename, and file contents.

This module allows a massive simplification of the `.ruby-version` and `audit.yaml` workflow code by looping over module instantiations rather than looping over all resources.

Use lists which are converted to sets rather than maps for enumerating repo targets.

`.ruby-version` is updated to 3.1.0 for all managed repos. This PR marks artichoke/artichoke as unmanaged since Ruby upgrades there are more involved.

Being able to loop over modules makes it easier to have several audit workflow templates. With these changes, every repo's `audit.yaml` only has the jobs it needs, rather than all jobs which may be conditionally toggled off.

This PR also updates `cargo-deny` to the latest 0.11.2 release.

The updates to `.ruby-version` and `.github/workflows/audit.yaml` are already deployed.

Fixes https://github.com/artichoke/project-infrastructure/issues/165.