### PR TITLE
Migrate crate reservations to module in artichoke github environment

### DIFF
--- a/github-org-artichoke/crate-reservation-repos.tf
+++ b/github-org-artichoke/crate-reservation-repos.tf
@@ -1,38 +1,34 @@
-locals {
-  crate_reservations = {
-    artichoke      = "artichoke-reserve"
-    artichokeruby  = "artichokeruby-reserve"
-    artichoke-ruby = "artichoke-ruby-reserve"
-    boba           = "boba-reserve"
-    invokedynamic  = "invokedynamic-reserve"
-  }
+module "reserve_artichoke" {
+  source = "../modules/crates.io-reservation-repository"
+
+  crate      = "artichoke"
+  repository = "artichoke-reserve"
 }
 
-resource "github_repository" "private_crate_reservation" {
-  for_each = local.crate_reservations
+module "reserve_artichokeruby" {
+  source = "../modules/crates.io-reservation-repository"
 
-  name         = each.value
-  description  = "📦 This repo was used to reserve the ${each.key} crate on crates.io"
-  homepage_url = "https://crates.io/crates/${each.key}"
+  crate      = "artichokeruby"
+  repository = "artichokeruby-reserve"
+}
 
-  visibility = "private"
+module "reserve_artichoke_ruby" {
+  source = "../modules/crates.io-reservation-repository"
 
-  has_downloads = false
-  has_issues    = false
-  has_projects  = false
-  has_wiki      = false
+  crate      = "artichoke-ruby"
+  repository = "artichoke-ruby-reserve"
+}
 
-  delete_branch_on_merge = true
-  vulnerability_alerts   = true
+module "reserve_boba" {
+  source = "../modules/crates.io-reservation-repository"
 
-  topics = [
-    "artichoke",
-    "reserve",
-    "rust",
-    "rust-crate",
-  ]
+  crate      = "boba"
+  repository = "boba-reserve"
+}
 
-  lifecycle {
-    prevent_destroy = true
-  }
+module "reserve_invokedynamic" {
+  source = "../modules/crates.io-reservation-repository"
+
+  crate      = "invokedynamic"
+  repository = "invokedynamic-reserve"
 }

--- a/modules/crates.io-reservation-repository/README.md
+++ b/modules/crates.io-reservation-repository/README.md
@@ -1,0 +1,27 @@
+# crates.io Reservation Repository
+
+This folder contains a Terraform module to manage private repositories that
+contain empty Rust crates used for reserving crate names on [crates.io].
+
+[crates.io]: https://crates.io/
+
+## Usage
+
+```terraform
+module "reserve_artichoke" {
+  source = "../modules/crates.io-reservation-repository"
+
+  crate      = "artichoke"
+  repository = "artichoke-reserve"
+}
+```
+
+## Parameters
+
+- `crate`: The name of the crate to be reserved on crates.io.
+- `repository`: The name of the repository to store the empty crate,
+  conventionally `${crate}-reserve`.
+
+## Outputs
+
+This module has no outputs.

--- a/modules/crates.io-reservation-repository/main.tf
+++ b/modules/crates.io-reservation-repository/main.tf
@@ -1,0 +1,35 @@
+terraform {
+  required_providers {
+    github = {
+      source  = "integrations/github"
+      version = "~> 4.20"
+    }
+  }
+}
+
+resource "github_repository" "this" {
+  name         = var.repository
+  description  = "📦 This repo was used to reserve the ${var.crate} crate on crates.io"
+  homepage_url = "https://crates.io/crates/${var.crate}"
+
+  visibility = "private"
+
+  has_downloads = false
+  has_issues    = false
+  has_projects  = false
+  has_wiki      = false
+
+  delete_branch_on_merge = true
+  vulnerability_alerts   = true
+
+  topics = [
+    "artichoke",
+    "reserve",
+    "rust",
+    "rust-crate",
+  ]
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}

--- a/modules/crates.io-reservation-repository/variables.tf
+++ b/modules/crates.io-reservation-repository/variables.tf
@@ -1,0 +1,9 @@
+variable "crate" {
+  description = "Crate name on crates.io"
+  type        = string
+}
+
+variable "repository" {
+  description = "GitHub repository"
+  type        = string
+}


### PR DESCRIPTION
Create a new Terraform module for creating and managing a GitHub repository for storing sources for crates.io crate reservations.

Migrate the `github-org-artichoke` environment to use this new module.

These changes are applied.