### PR TITLE
Migrate `hashicorp/template` provider to `templatefile` builtin function

### DIFF
--- a/github-org-artichoke/.terraform.lock.hcl
+++ b/github-org-artichoke/.terraform.lock.hcl
@@ -1,9 +1,26 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/template" {
+  version = "2.2.0"
+  hashes = [
+    "h1:0wlehNaxBX7GJQnPfQwTNvvAf38Jm0Nv7ssKGMaG6Og=",
+    "zh:01702196f0a0492ec07917db7aaa595843d8f171dc195f4c988d2ffca2a06386",
+    "zh:09aae3da826ba3d7df69efeb25d146a1de0d03e951d35019a0f80e4f58c89b53",
+    "zh:09ba83c0625b6fe0a954da6fbd0c355ac0b7f07f86c91a2a97849140fea49603",
+    "zh:0e3a6c8e16f17f19010accd0844187d524580d9fdb0731f675ffcf4afba03d16",
+    "zh:45f2c594b6f2f34ea663704cc72048b212fe7d16fb4cfd959365fa997228a776",
+    "zh:77ea3e5a0446784d77114b5e851c970a3dde1e08fa6de38210b8385d7605d451",
+    "zh:8a154388f3708e3df5a69122a23bdfaf760a523788a5081976b3d5616f7d30ae",
+    "zh:992843002f2db5a11e626b3fc23dc0c87ad3729b3b3cff08e32ffb3df97edbde",
+    "zh:ad906f4cebd3ec5e43d5cd6dc8f4c5c9cc3b33d2243c89c5fc18f97f7277b51d",
+    "zh:c979425ddb256511137ecd093e23283234da0154b7fa8b21c2687182d9aea8b2",
+  ]
+}
+
 provider "registry.terraform.io/integrations/github" {
   version     = "4.20.0"
-  constraints = "~> 4.20"
+  constraints = "~> 4.12, ~> 4.20"
   hashes = [
     "h1:Cn8FlSQya+gweH7ApeGdjcx9gyloFPXW6Zsb6Kc8X74=",
     "zh:1501c3ccaf624cf6d9d311eb59f911fa0cf431d4728af3b103e01c0eb4201efb",

--- a/github-org-artichoke/.terraform.lock.hcl
+++ b/github-org-artichoke/.terraform.lock.hcl
@@ -1,26 +1,9 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
-provider "registry.terraform.io/hashicorp/template" {
-  version = "2.2.0"
-  hashes = [
-    "h1:0wlehNaxBX7GJQnPfQwTNvvAf38Jm0Nv7ssKGMaG6Og=",
-    "zh:01702196f0a0492ec07917db7aaa595843d8f171dc195f4c988d2ffca2a06386",
-    "zh:09aae3da826ba3d7df69efeb25d146a1de0d03e951d35019a0f80e4f58c89b53",
-    "zh:09ba83c0625b6fe0a954da6fbd0c355ac0b7f07f86c91a2a97849140fea49603",
-    "zh:0e3a6c8e16f17f19010accd0844187d524580d9fdb0731f675ffcf4afba03d16",
-    "zh:45f2c594b6f2f34ea663704cc72048b212fe7d16fb4cfd959365fa997228a776",
-    "zh:77ea3e5a0446784d77114b5e851c970a3dde1e08fa6de38210b8385d7605d451",
-    "zh:8a154388f3708e3df5a69122a23bdfaf760a523788a5081976b3d5616f7d30ae",
-    "zh:992843002f2db5a11e626b3fc23dc0c87ad3729b3b3cff08e32ffb3df97edbde",
-    "zh:ad906f4cebd3ec5e43d5cd6dc8f4c5c9cc3b33d2243c89c5fc18f97f7277b51d",
-    "zh:c979425ddb256511137ecd093e23283234da0154b7fa8b21c2687182d9aea8b2",
-  ]
-}
-
 provider "registry.terraform.io/integrations/github" {
   version     = "4.20.0"
-  constraints = "~> 4.12, ~> 4.20"
+  constraints = "~> 4.20"
   hashes = [
     "h1:Cn8FlSQya+gweH7ApeGdjcx9gyloFPXW6Zsb6Kc8X74=",
     "zh:1501c3ccaf624cf6d9d311eb59f911fa0cf431d4728af3b103e01c0eb4201efb",

--- a/github-org-artichoke/github-actions-workflow-audit.tf
+++ b/github-org-artichoke/github-actions-workflow-audit.tf
@@ -41,6 +41,10 @@ locals {
   audit_node_ruby_rust_repos = [
     "playground", // https://github.com/artichoke/playground
   ]
+
+  // https://github.com/EmbarkStudios/cargo-deny/releases/tag/0.11.2
+  cargo_deny_version          = "0.11.2"
+  cargo_deny_release_base_url = "https://github.com/EmbarkStudios/cargo-deny/releases/download"
 }
 
 module "audit_workflow_node" {
@@ -112,25 +116,22 @@ output "audit_workflow_node_ruby_branches" {
   HREFS
 }
 
-data "template_file" "audit_workflow_ruby_rust" {
-  template = file("${path.module}/templates/audit-workflow-ruby-rust.yaml")
-
-  vars = {
-    // https://github.com/EmbarkStudios/cargo-deny/releases/tag/0.11.2
-    cargo_deny_version = "0.11.2"
-    release_base_url   = "https://github.com/EmbarkStudios/cargo-deny/releases/download"
-  }
-}
-
 module "audit_workflow_ruby_rust" {
   source   = "../modules/update-github-repository-file"
   for_each = local.force_bump_audit_ruby_rust ? toset(local.audit_ruby_rust_repos) : toset([])
 
-  organization  = "artichoke"
-  repository    = each.value
-  base_branch   = "trunk"
-  file_path     = ".github/workflows/audit.yaml"
-  file_contents = data.template_file.audit_workflow_ruby_rust.rendered
+  organization = "artichoke"
+  repository   = each.value
+  base_branch  = "trunk"
+  file_path    = ".github/workflows/audit.yaml"
+
+  file_contents = templatefile(
+    "${path.module}/templates/audit-workflow-ruby-rust.yaml",
+    {
+      cargo_deny_version = local.cargo_deny_version,
+      release_base_url   = local.cargo_deny_release_base_url,
+    }
+  )
 }
 
 output "audit_workflow_ruby_rust_branches" {
@@ -145,25 +146,22 @@ output "audit_workflow_ruby_rust_branches" {
   HREFS
 }
 
-data "template_file" "audit_workflow_node_ruby_rust" {
-  template = file("${path.module}/templates/audit-workflow-node-ruby-rust.yaml")
-
-  vars = {
-    // https://github.com/EmbarkStudios/cargo-deny/releases/tag/0.11.2
-    cargo_deny_version = "0.11.2"
-    release_base_url   = "https://github.com/EmbarkStudios/cargo-deny/releases/download"
-  }
-}
-
 module "audit_workflow_node_ruby_rust" {
   source   = "../modules/update-github-repository-file"
   for_each = local.force_bump_audit_node_ruby_rust ? toset(local.audit_node_ruby_rust_repos) : toset([])
 
-  organization  = "artichoke"
-  repository    = each.value
-  base_branch   = "trunk"
-  file_path     = ".github/workflows/audit.yaml"
-  file_contents = data.template_file.audit_workflow_node_ruby_rust.rendered
+  organization = "artichoke"
+  repository   = each.value
+  base_branch  = "trunk"
+  file_path    = ".github/workflows/audit.yaml"
+
+  file_contents = templatefile(
+    "${path.module}/templates/audit-workflow-node-ruby-rust.yaml",
+    {
+      cargo_deny_version = local.cargo_deny_version,
+      release_base_url   = local.cargo_deny_release_base_url,
+    }
+  )
 }
 
 output "audit_workflow_node_ruby_rust_branches" {

--- a/github-org-artichoke/github-actions-workflow-audit.tf
+++ b/github-org-artichoke/github-actions-workflow-audit.tf
@@ -23,7 +23,7 @@ locals {
     "rubyconf",            // https://github.com/artichoke/rubyconf
   ]
 
-  force_bump_audit_ruby_rust = false
+  force_bump_audit_ruby_rust = true
   audit_ruby_rust_repos = [
     "artichoke",             // https://github.com/artichoke/artichoke
     "boba",                  // https://github.com/artichoke/boba
@@ -37,13 +37,13 @@ locals {
     "strudel",               // https://github.com/artichoke/strudel
   ]
 
-  force_bump_audit_node_ruby_rust = false
+  force_bump_audit_node_ruby_rust = true
   audit_node_ruby_rust_repos = [
     "playground", // https://github.com/artichoke/playground
   ]
 
   // https://github.com/EmbarkStudios/cargo-deny/releases/tag/0.11.2
-  cargo_deny_version          = "0.11.2"
+  cargo_deny_version          = "0.11.3"
   cargo_deny_release_base_url = "https://github.com/EmbarkStudios/cargo-deny/releases/download"
 }
 

--- a/github-org-artichoke/github-actions-workflow-audit.tf
+++ b/github-org-artichoke/github-actions-workflow-audit.tf
@@ -23,7 +23,7 @@ locals {
     "rubyconf",            // https://github.com/artichoke/rubyconf
   ]
 
-  force_bump_audit_ruby_rust = true
+  force_bump_audit_ruby_rust = false
   audit_ruby_rust_repos = [
     "artichoke",             // https://github.com/artichoke/artichoke
     "boba",                  // https://github.com/artichoke/boba
@@ -37,7 +37,7 @@ locals {
     "strudel",               // https://github.com/artichoke/strudel
   ]
 
-  force_bump_audit_node_ruby_rust = true
+  force_bump_audit_node_ruby_rust = false
   audit_node_ruby_rust_repos = [
     "playground", // https://github.com/artichoke/playground
   ]


### PR DESCRIPTION
The `hashicorp/template` provider is deprecated:

- https://github.com/hashicorp/terraform-provider-template/issues/85
- https://registry.terraform.io/providers/hashicorp/template/latest

> For Terraform 0.12 and later, the template_file data source has been superseded by [the `templatefile` function](https://github.com/docs/configuration/functions/templatefile.html), which can be used directly in expressions without creating a separate data resource.

This change is rolled out and tested with the upgrade of `cargo-deny` to 0.11.3.

`hashicorp/template` provider is no longer in terraform state and is removed from the provider lockfile.

These changes have been applied.