### PR TITLE
Add a Rake task for locking terraform providers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,7 @@ rake lint:rubocop                 # Run RuboCop
 rake lint:rubocop:auto_correct    # Auto-correct RuboCop offenses
 rake lint:terraform               # Lint Terraform sources
 rake release:markdown_link_check  # Check for broken links in markdown files
+rake terraform:providers:lock     # Lock terraform providers on all plaforms in all environments
 ```
 
 To lint Ruby sources, project-infrastructure uses [RuboCop]. RuboCop runs as

--- a/github-org-artichoke-ruby/.terraform.lock.hcl
+++ b/github-org-artichoke-ruby/.terraform.lock.hcl
@@ -5,7 +5,9 @@ provider "registry.terraform.io/integrations/github" {
   version     = "4.20.0"
   constraints = "~> 4.20"
   hashes = [
+    "h1:8aEltkf7TY+fPzD6t1jjk5zVEsj7FHLzhNFsUpZhohA=",
     "h1:Cn8FlSQya+gweH7ApeGdjcx9gyloFPXW6Zsb6Kc8X74=",
+    "h1:ogDrOjYdyxOqIHEnyrf7jRgQCOVmE5dk3+u1MHylsVI=",
     "zh:1501c3ccaf624cf6d9d311eb59f911fa0cf431d4728af3b103e01c0eb4201efb",
     "zh:18eca616b2eb0868fd411835b5d04898ef7a82803ac900571bfc4bccdda1192e",
     "zh:194a711aee04329bbfff57a7c882bca55e9d96fc665c4aefb0e73bd214587c35",

--- a/github-org-artichoke/.terraform.lock.hcl
+++ b/github-org-artichoke/.terraform.lock.hcl
@@ -5,7 +5,9 @@ provider "registry.terraform.io/integrations/github" {
   version     = "4.20.0"
   constraints = "~> 4.20"
   hashes = [
+    "h1:8aEltkf7TY+fPzD6t1jjk5zVEsj7FHLzhNFsUpZhohA=",
     "h1:Cn8FlSQya+gweH7ApeGdjcx9gyloFPXW6Zsb6Kc8X74=",
+    "h1:ogDrOjYdyxOqIHEnyrf7jRgQCOVmE5dk3+u1MHylsVI=",
     "zh:1501c3ccaf624cf6d9d311eb59f911fa0cf431d4728af3b103e01c0eb4201efb",
     "zh:18eca616b2eb0868fd411835b5d04898ef7a82803ac900571bfc4bccdda1192e",
     "zh:194a711aee04329bbfff57a7c882bca55e9d96fc665c4aefb0e73bd214587c35",

--- a/github-org-artichokeruby/.terraform.lock.hcl
+++ b/github-org-artichokeruby/.terraform.lock.hcl
@@ -5,7 +5,9 @@ provider "registry.terraform.io/integrations/github" {
   version     = "4.20.0"
   constraints = "~> 4.20"
   hashes = [
+    "h1:8aEltkf7TY+fPzD6t1jjk5zVEsj7FHLzhNFsUpZhohA=",
     "h1:Cn8FlSQya+gweH7ApeGdjcx9gyloFPXW6Zsb6Kc8X74=",
+    "h1:ogDrOjYdyxOqIHEnyrf7jRgQCOVmE5dk3+u1MHylsVI=",
     "zh:1501c3ccaf624cf6d9d311eb59f911fa0cf431d4728af3b103e01c0eb4201efb",
     "zh:18eca616b2eb0868fd411835b5d04898ef7a82803ac900571bfc4bccdda1192e",
     "zh:194a711aee04329bbfff57a7c882bca55e9d96fc665c4aefb0e73bd214587c35",

--- a/remote-state/.terraform.lock.hcl
+++ b/remote-state/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   constraints = "~> 3.47"
   hashes = [
     "h1:YNOblHBUf+XTjGTfIIsAMGp4weXB+tmQrMPCrpmM1/U=",
+    "h1:kjdnHC/zdxpv9rZgVU1AFjMuCuDjAKs5fPxldmMXdXc=",
     "h1:y9b9LluBQGrZHURGY1Xmrhb+zQ6qRit3oqFSLijkGe0=",
     "zh:00767509c13c0d1c7ad6af702c6942e6572aa6d529b40a00baacc0e73faafea2",
     "zh:03aafdc903ad49c2eda03889f927f44212674c50e475a9c6298850381319eec2",


### PR DESCRIPTION
https://www.terraform.io/cli/commands/providers/lock#specifying-target-platforms

The `rake terraform:providers:lock` task adds provider hashes to the lockfile in all environments for Windows, macOS, and Linux.

This task will make monthly @dependabot updates easier to roll up and will not require doing `terraform init`.