### PR TITLE
Migrate artichoke GitHub org webhook to tf module, add security events webhook

### DIFF
--- a/github-org-artichoke/main.tf
+++ b/github-org-artichoke/main.tf
@@ -8,31 +8,19 @@ terraform {
   }
 }
 
-variable "github_token" {
-  type      = string
-  sensitive = true
-}
-
-variable "discord_api_secret" {
-  type      = string
-  sensitive = true
-}
-
 provider "github" {
   token = var.github_token
   owner = "artichoke"
 }
 
-resource "github_organization_webhook" "discord" {
-  configuration {
-    url          = "https://discordapp.com/api/webhooks/616536749367099402/${var.discord_api_secret}/github"
-    content_type = "json"
-    insecure_ssl = false
-  }
+module "git_events_webhook" {
+  source = "../modules/github-discord-webhook"
 
-  active = true
+  webhook_id    = var.discord_git_events_webhook_id
+  webhook_token = var.discord_git_events_webhook_token
 
-  events = [
+  # https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads
+  github_events = [
     "commit_comment",
     "create",
     "delete",
@@ -41,6 +29,31 @@ resource "github_organization_webhook" "discord" {
     "pull_request",
     "pull_request_review",
     "pull_request_review_comment",
+  ]
+}
+
+module "security_events_webhook" {
+  source = "../modules/github-discord-webhook"
+
+  webhook_id    = var.discord_security_events_webhook_id
+  webhook_token = var.discord_security_events_webhook_token
+
+  # https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads
+  github_events = [
+    "branch_protection_rule",
+    "code_scanning_alert",
+    "deploy_key",
+    "member",
+    "membership",
+    "organization",
+    "org_block",
+    "public",
+    "repository",
+    "repository_import",
+    "repository_vulnerability_alert",
+    "secret_scanning_alert",
+    "team",
+    "team_add",
   ]
 }
 

--- a/github-org-artichoke/variables.tf
+++ b/github-org-artichoke/variables.tf
@@ -1,0 +1,27 @@
+variable "github_token" {
+  description = "GitHub Personal Access Token (PAT) with full access"
+  type        = string
+  sensitive   = true
+}
+
+variable "discord_git_events_webhook_id" {
+  description = "Discord webhook id for #gitlog"
+  type        = string
+}
+
+variable "discord_git_events_webhook_token" {
+  description = "Discord webhook secret token for #gitlog"
+  type        = string
+  sensitive   = true
+}
+
+variable "discord_security_events_webhook_id" {
+  description = "Discord webhook id for #security-events"
+  type        = string
+}
+
+variable "discord_security_events_webhook_token" {
+  description = "Discord webhook secret token for #security-events"
+  type        = string
+  sensitive   = true
+}


### PR DESCRIPTION
Some state surgery was required.

```console
$ aws-vault exec artichokeruby-forge-admin -- terraform state mv github_organization_webhook.discord module.git_events_webhook.github_organization_webhook.discord
Move "github_organization_webhook.discord" to "module.git_events_webhook.github_organization_webhook.discord"
Successfully moved 1 object(s).
```

These changes are applied.

```console
$ aws-vault exec artichokeruby-forge-admin -- terraform plan
module.reserve_artichoke.github_repository.this: Refreshing state... [id=artichoke-reserve]
github_repository.artichoke_ci: Refreshing state... [id=artichoke-ci]
github_repository.rubyconf2019_artichoke_run: Refreshing state... [id=rubyconf2019.artichoke.run]
github_repository.mruby: Refreshing state... [id=mruby]
github_repository.rust_onig: Refreshing state... [id=rust-onig]
github_repository.logo: Refreshing state... [id=logo]
github_repository.raw_parts: Refreshing state... [id=raw-parts]
github_repository.clang_format: Refreshing state... [id=clang-format]
github_repository.onigmo: Refreshing state... [id=Onigmo]
github_repository.playground: Refreshing state... [id=playground]
module.reserve_invokedynamic.github_repository.this: Refreshing state... [id=invokedynamic-reserve]
github_repository.rust_mersenne_twister: Refreshing state... [id=rust-mersenne-twister]
github_repository.boba: Refreshing state... [id=boba]
github_repository.docker_artichoke_nightly: Refreshing state... [id=docker-artichoke-nightly]
github_repository.rubyconf: Refreshing state... [id=rubyconf]
module.git_events_webhook.github_organization_webhook.discord: Refreshing state... [id=198671336]
github_repository.ruby_file_expand_path: Refreshing state... [id=ruby-file-expand-path]
module.reserve_artichoke_ruby.github_repository.this: Refreshing state... [id=artichoke-ruby-reserve]
github_repository.rand_mt: Refreshing state... [id=rand_mt]
github_repository.strudel: Refreshing state... [id=strudel]
github_repository.www_artichokeruby_org: Refreshing state... [id=www.artichokeruby.org]
github_repository.focaccia: Refreshing state... [id=focaccia]
github_repository.roe: Refreshing state... [id=roe]
github_repository.nightly: Refreshing state... [id=nightly]
module.org_members.github_membership.admins["lopopolo"]: Refreshing state... [id=artichoke:lopopolo]
github_repository.ferrocarril: Refreshing state... [id=ferrocarril]
github_repository.mspec: Refreshing state... [id=mspec]
module.org_members.github_membership.members["artichoke-ci"]: Refreshing state... [id=artichoke:artichoke-ci]
github_repository.jasper: Refreshing state... [id=jasper]
module.team_cratesio_publishers.github_team.this: Refreshing state... [id=4053636]
github_repository.oniguruma: Refreshing state... [id=oniguruma]
github_repository.project_infrastructure: Refreshing state... [id=project-infrastructure]
github_repository.spec: Refreshing state... [id=spec]
github_repository.cactusref: Refreshing state... [id=cactusref]
module.reserve_boba.github_repository.this: Refreshing state... [id=boba-reserve]
github_repository.intaglio: Refreshing state... [id=intaglio]
github_repository.ruby: Refreshing state... [id=ruby]
github_repository.artichoke: Refreshing state... [id=artichoke]
module.reserve_artichokeruby.github_repository.this: Refreshing state... [id=artichokeruby-reserve]
module.team_ci.github_team.this: Refreshing state... [id=3544139]
github_repository.artichoke_github_io: Refreshing state... [id=artichoke.github.io]
github_branch_default.rust_onig: Refreshing state... [id=rust-onig]
github_branch_default.mruby: Refreshing state... [id=mruby]
github_actions_organization_secret.dockerhub_user: Refreshing state... [id=DOCKERHUB_USER]
github_actions_organization_secret.dockerhub_token: Refreshing state... [id=DOCKERHUB_TOKEN]
github_branch_default.mspec: Refreshing state... [id=mspec]
module.team_cratesio_publishers.github_team_members.this: Refreshing state... [id=4053636]
github_branch_default.spec: Refreshing state... [id=spec]
github_branch_default.ruby: Refreshing state... [id=ruby]
module.team_ci.github_team_members.this: Refreshing state... [id=3544139]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following
symbols:
  + create
  ~ update in-place

Terraform will perform the following actions:

  # module.git_events_webhook.github_organization_webhook.discord will be updated in-place
  ~ resource "github_organization_webhook" "discord" {
        id     = "198671336"
        # (4 unchanged attributes hidden)

      ~ configuration {
          ~ url          = (sensitive value)
            # (3 unchanged attributes hidden)
        }
    }

  # module.security_events_webhook.github_organization_webhook.discord will be created
  + resource "github_organization_webhook" "discord" {
      + active = true
      + etag   = (known after apply)
      + events = [
          + "branch_protection_rule",
          + "code_scanning_alert",
          + "deploy_key",
          + "member",
          + "membership",
          + "org_block",
          + "organization",
          + "public",
          + "repository",
          + "repository_import",
          + "repository_vulnerability_alert",
          + "secret_scanning_alert",
          + "team",
          + "team_add",
        ]
      + id     = (known after apply)
      + url    = (known after apply)

      + configuration {
          + content_type = "json"
          + insecure_ssl = false
          + url          = (sensitive value)
        }
    }

Plan: 1 to add, 1 to change, 0 to destroy.
╷
│ Warning: Value for undeclared variable
│
│ The root module does not declare a variable named "discord_api_secret" but a value was found in file "secrets.auto.tfvars". If
│ you meant to use this value, add a "variable" block to the configuration.
│
│ To silence these warnings, use TF_VAR_... environment variables to provide certain "global" settings to all configurations in
│ your organization. To reduce the verbosity of these warnings, use the -compact-warnings option.
╵

─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so Terraform can't guarantee to take exactly these actions if you run
"terraform apply" now.
$ aws-vault exec artichokeruby-forge-admin -- terraform apply
github_repository.jasper: Refreshing state... [id=jasper]
github_repository.rand_mt: Refreshing state... [id=rand_mt]
github_repository.mspec: Refreshing state... [id=mspec]
github_repository.www_artichokeruby_org: Refreshing state... [id=www.artichokeruby.org]
github_repository.artichoke: Refreshing state... [id=artichoke]
module.org_members.github_membership.members["artichoke-ci"]: Refreshing state... [id=artichoke:artichoke-ci]
module.reserve_invokedynamic.github_repository.this: Refreshing state... [id=invokedynamic-reserve]
github_repository.logo: Refreshing state... [id=logo]
github_repository.artichoke_github_io: Refreshing state... [id=artichoke.github.io]
github_repository.onigmo: Refreshing state... [id=Onigmo]
github_repository.playground: Refreshing state... [id=playground]
github_repository.rubyconf2019_artichoke_run: Refreshing state... [id=rubyconf2019.artichoke.run]
github_repository.artichoke_ci: Refreshing state... [id=artichoke-ci]
github_repository.rubyconf: Refreshing state... [id=rubyconf]
module.reserve_boba.github_repository.this: Refreshing state... [id=boba-reserve]
github_repository.ruby: Refreshing state... [id=ruby]
github_repository.spec: Refreshing state... [id=spec]
github_repository.rust_mersenne_twister: Refreshing state... [id=rust-mersenne-twister]
github_repository.oniguruma: Refreshing state... [id=oniguruma]
github_repository.docker_artichoke_nightly: Refreshing state... [id=docker-artichoke-nightly]
module.reserve_artichoke.github_repository.this: Refreshing state... [id=artichoke-reserve]
github_repository.ruby_file_expand_path: Refreshing state... [id=ruby-file-expand-path]
module.org_members.github_membership.admins["lopopolo"]: Refreshing state... [id=artichoke:lopopolo]
github_repository.boba: Refreshing state... [id=boba]
module.git_events_webhook.github_organization_webhook.discord: Refreshing state... [id=198671336]
module.reserve_artichoke_ruby.github_repository.this: Refreshing state... [id=artichoke-ruby-reserve]
github_repository.rust_onig: Refreshing state... [id=rust-onig]
module.reserve_artichokeruby.github_repository.this: Refreshing state... [id=artichokeruby-reserve]
github_repository.roe: Refreshing state... [id=roe]
module.team_cratesio_publishers.github_team.this: Refreshing state... [id=4053636]
github_repository.strudel: Refreshing state... [id=strudel]
github_repository.cactusref: Refreshing state... [id=cactusref]
module.team_ci.github_team.this: Refreshing state... [id=3544139]
github_repository.raw_parts: Refreshing state... [id=raw-parts]
github_repository.intaglio: Refreshing state... [id=intaglio]
github_repository.mruby: Refreshing state... [id=mruby]
github_repository.ferrocarril: Refreshing state... [id=ferrocarril]
github_repository.clang_format: Refreshing state... [id=clang-format]
github_repository.project_infrastructure: Refreshing state... [id=project-infrastructure]
github_repository.focaccia: Refreshing state... [id=focaccia]
github_repository.nightly: Refreshing state... [id=nightly]
github_branch_default.mspec: Refreshing state... [id=mspec]
github_branch_default.ruby: Refreshing state... [id=ruby]
github_branch_default.spec: Refreshing state... [id=spec]
github_actions_organization_secret.dockerhub_user: Refreshing state... [id=DOCKERHUB_USER]
github_actions_organization_secret.dockerhub_token: Refreshing state... [id=DOCKERHUB_TOKEN]
github_branch_default.rust_onig: Refreshing state... [id=rust-onig]
module.team_cratesio_publishers.github_team_members.this: Refreshing state... [id=4053636]
module.team_ci.github_team_members.this: Refreshing state... [id=3544139]
github_branch_default.mruby: Refreshing state... [id=mruby]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following
symbols:
  + create
  ~ update in-place

Terraform will perform the following actions:

  # module.git_events_webhook.github_organization_webhook.discord will be updated in-place
  ~ resource "github_organization_webhook" "discord" {
        id     = "198671336"
        # (4 unchanged attributes hidden)

      ~ configuration {
          ~ url          = (sensitive value)
            # (3 unchanged attributes hidden)
        }
    }

  # module.security_events_webhook.github_organization_webhook.discord will be created
  + resource "github_organization_webhook" "discord" {
      + active = true
      + etag   = (known after apply)
      + events = [
          + "branch_protection_rule",
          + "code_scanning_alert",
          + "deploy_key",
          + "member",
          + "membership",
          + "org_block",
          + "organization",
          + "public",
          + "repository",
          + "repository_import",
          + "repository_vulnerability_alert",
          + "secret_scanning_alert",
          + "team",
          + "team_add",
        ]
      + id     = (known after apply)
      + url    = (known after apply)

      + configuration {
          + content_type = "json"
          + insecure_ssl = false
          + url          = (sensitive value)
        }
    }

Plan: 1 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

module.security_events_webhook.github_organization_webhook.discord: Creating...
module.git_events_webhook.github_organization_webhook.discord: Modifying... [id=198671336]
module.security_events_webhook.github_organization_webhook.discord: Creation complete after 3s [id=343478090]
module.git_events_webhook.github_organization_webhook.discord: Modifications complete after 3s [id=198671336]

Apply complete! Resources: 1 added, 1 changed, 0 destroyed.
```