### PR TITLE
Cleanup `github-org-artichoke` environment

### DIFF
--- a/github-org-artichoke/README.md
+++ b/github-org-artichoke/README.md
@@ -16,7 +16,14 @@ This environment requires several variables to be set:
 
 - `github_token`: A [github access token] with at least `repo`, `admin:org`,
   `admin:org_hook`, and `workflow` scopes.
-- `discord_api_secret`: A Discord webhook token.
+- `discord_git_events_webhook_id`: A Discord webhook id for delivering git audit
+  events.
+- `discord_git_events_webhook_token`: A Discord webhook token for delivering git
+  audit events.
+- `discord_security_events_webhook_id`: A Discord webhook id for delivering
+  security audit events.
+- `discord_security_events_webhook_token`: A Discord webhook token for
+  delivering security audit events.
 - `dockerhub_user`: A Docker Hub user for pushing container images in GitHub
   Actions workflows.
 - `dockerhub_token`: A Docker Hub access token for the given Docker Hub user.

--- a/github-org-artichoke/github-actions-workflow-audit.tf
+++ b/github-org-artichoke/github-actions-workflow-audit.tf
@@ -58,18 +58,6 @@ module "audit_workflow_node" {
   file_contents = file("${path.module}/templates/audit-workflow-node.yaml")
 }
 
-output "audit_workflow_node_branches" {
-  value = <<-HREFS
-
-  ## Branch URLs:
-
-  ${join(
-  "\n",
-  formatlist("- %s", [for repo, audit_workflow in module.audit_workflow_node : audit_workflow.branch_href])
-)}
-  HREFS
-}
-
 module "audit_workflow_ruby" {
   source   = "../modules/update-github-repository-file"
   for_each = local.force_bump_audit_ruby ? toset(local.audit_ruby_repos) : toset([])
@@ -81,18 +69,6 @@ module "audit_workflow_ruby" {
   file_contents = file("${path.module}/templates/audit-workflow-ruby.yaml")
 }
 
-output "audit_workflow_ruby_branches" {
-  value = <<-HREFS
-
-  ## Branch URLs:
-
-  ${join(
-  "\n",
-  formatlist("- %s", [for repo, audit_workflow in module.audit_workflow_ruby : audit_workflow.branch_href])
-)}
-  HREFS
-}
-
 module "audit_workflow_node_ruby" {
   source   = "../modules/update-github-repository-file"
   for_each = local.force_bump_audit_node_ruby ? toset(local.audit_node_ruby_repos) : toset([])
@@ -102,18 +78,6 @@ module "audit_workflow_node_ruby" {
   base_branch   = "trunk"
   file_path     = ".github/workflows/audit.yaml"
   file_contents = file("${path.module}/templates/audit-workflow-node-ruby.yaml")
-}
-
-output "audit_workflow_node_ruby_branches" {
-  value = <<-HREFS
-
-  ## Branch URLs:
-
-  ${join(
-  "\n",
-  formatlist("- %s", [for repo, audit_workflow in module.audit_workflow_node_ruby : audit_workflow.branch_href])
-)}
-  HREFS
 }
 
 module "audit_workflow_ruby_rust" {
@@ -134,18 +98,6 @@ module "audit_workflow_ruby_rust" {
   )
 }
 
-output "audit_workflow_ruby_rust_branches" {
-  value = <<-HREFS
-
-  ## Branch URLs:
-
-  ${join(
-  "\n",
-  formatlist("- %s", [for repo, audit_workflow in module.audit_workflow_ruby_rust : audit_workflow.branch_href])
-)}
-  HREFS
-}
-
 module "audit_workflow_node_ruby_rust" {
   source   = "../modules/update-github-repository-file"
   for_each = local.force_bump_audit_node_ruby_rust ? toset(local.audit_node_ruby_rust_repos) : toset([])
@@ -162,16 +114,4 @@ module "audit_workflow_node_ruby_rust" {
       release_base_url   = local.cargo_deny_release_base_url,
     }
   )
-}
-
-output "audit_workflow_node_ruby_rust_branches" {
-  value = <<-HREFS
-
-  ## Branch URLs:
-
-  ${join(
-  "\n",
-  formatlist("- %s", [for repo, audit_workflow in module.audit_workflow_node_ruby_rust : audit_workflow.branch_href])
-)}
-  HREFS
 }

--- a/github-org-artichoke/organization-secrets.tf
+++ b/github-org-artichoke/organization-secrets.tf
@@ -1,13 +1,3 @@
-variable "dockerhub_token" {
-  type      = string
-  sensitive = true
-}
-
-variable "dockerhub_user" {
-  type      = string
-  sensitive = true
-}
-
 resource "github_actions_organization_secret" "dockerhub_token" {
   secret_name     = "DOCKERHUB_TOKEN"
   visibility      = "selected"

--- a/github-org-artichoke/outputs.tf
+++ b/github-org-artichoke/outputs.tf
@@ -1,0 +1,30 @@
+output "audit_workflow_node_branches" {
+  description = "Links to GitHub with changes to the `audit` workflow for Node.js repos"
+  value       = join("\n", concat(length(module.audit_workflow_node) == 0 ? [] : ["## Branches", ""], formatlist("- %s", [for repo, audit_workflow in module.audit_workflow_node : audit_workflow.branch_href])))
+}
+
+output "audit_workflow_ruby_branches" {
+  description = "Links to GitHub with changes to the `audit` workflow for Ruby repos"
+  value       = join("\n", concat(length(module.audit_workflow_ruby) == 0 ? [] : ["## Branches", ""], formatlist("- %s", [for repo, audit_workflow in module.audit_workflow_ruby : audit_workflow.branch_href])))
+}
+
+output "audit_workflow_node_ruby_branches" {
+  description = "Links to GitHub with changes to the `audit` workflow for Node.js and Ruby repos"
+  value       = join("\n", concat(length(module.audit_workflow_node_ruby) == 0 ? [] : ["## Branches", ""], formatlist("- %s", [for repo, audit_workflow in module.audit_workflow_node_ruby : audit_workflow.branch_href])))
+}
+
+output "audit_workflow_ruby_rust_branches" {
+  description = "Links to GitHub with changes to the `audit` workflow for Ruby and Rust repos"
+  value       = join("\n", concat(length(module.audit_workflow_ruby_rust) == 0 ? [] : ["## Branches", ""], formatlist("- %s", [for repo, audit_workflow in module.audit_workflow_ruby_rust : audit_workflow.branch_href])))
+}
+
+output "audit_workflow_node_ruby_rust_branches" {
+  description = "Links to GitHub with changes to the `audit` workflow for Node.js, Ruby, and Rust repos"
+  value       = join("\n", concat(length(module.audit_workflow_node_ruby_rust) == 0 ? [] : ["## Branches", ""], formatlist("- %s", [for repo, audit_workflow in module.audit_workflow_node_ruby_rust : audit_workflow.branch_href])))
+}
+
+output "ruby_version_branches" {
+  description = "A list of links to branches on GitHub with changes to .ruby-version"
+  value       = join("\n", concat(length(module.ruby_version) == 0 ? [] : ["## Branches", ""], formatlist("- %s", [for repo, ruby_version in module.ruby_version : ruby_version.branch_href])))
+}
+

--- a/github-org-artichoke/ruby-version.tf
+++ b/github-org-artichoke/ruby-version.tf
@@ -37,15 +37,3 @@ module "ruby_version" {
   file_path     = ".ruby-version"
   file_contents = "${local.ruby_version}\n"
 }
-
-output "ruby_version_branches" {
-  value = <<-HREFS
-
-  ## Branch URLs:
-
-  ${join(
-  "\n",
-  formatlist("- %s", [for repo, ruby_version in module.ruby_version : ruby_version.branch_href])
-)}
-  HREFS
-}

--- a/github-org-artichoke/variables.tf
+++ b/github-org-artichoke/variables.tf
@@ -25,3 +25,15 @@ variable "discord_security_events_webhook_token" {
   type        = string
   sensitive   = true
 }
+
+variable "dockerhub_user" {
+  description = "Docker Hub user for pushing container images in CI"
+  type        = string
+  sensitive   = true
+}
+
+variable "dockerhub_token" {
+  description = "Docker Hub access token for the given Docker Hub user"
+  type        = string
+  sensitive   = true
+}


### PR DESCRIPTION
- Move all outputs to `outputs.tf`.
- Update README to document discord webhook variables.
- Update outputs for list of links to output `""` when there are no
  active PRs.
- Move Docker Hub secrets variables to `variables.tf`.

These changes are applied. New outputs:

```
Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

Releasing state lock. This may take a few moments...

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

Outputs:

audit_workflow_node_branches = ""
audit_workflow_node_ruby_branches = ""
audit_workflow_node_ruby_rust_branches = ""
audit_workflow_ruby_branches = ""
audit_workflow_ruby_rust_branches = ""
ruby_version_branches = ""
```