### PR TITLE
Pass cargo-deny config to audit templates as an object

### DIFF
--- a/github-org-artichoke/github-actions-workflow-audit.tf
+++ b/github-org-artichoke/github-actions-workflow-audit.tf
@@ -43,8 +43,10 @@ locals {
   ]
 
   // https://github.com/EmbarkStudios/cargo-deny/releases/tag/0.11.2
-  cargo_deny_version          = "0.11.3"
-  cargo_deny_release_base_url = "https://github.com/EmbarkStudios/cargo-deny/releases/download"
+  cargo_deny = {
+    version  = "0.11.3"
+    base_url = "https://github.com/EmbarkStudios/cargo-deny/releases/download"
+  }
 }
 
 module "audit_workflow_node" {
@@ -89,13 +91,7 @@ module "audit_workflow_ruby_rust" {
   base_branch  = "trunk"
   file_path    = ".github/workflows/audit.yaml"
 
-  file_contents = templatefile(
-    "${path.module}/templates/audit-workflow-ruby-rust.yaml",
-    {
-      cargo_deny_version = local.cargo_deny_version,
-      release_base_url   = local.cargo_deny_release_base_url,
-    }
-  )
+  file_contents = templatefile("${path.module}/templates/audit-workflow-ruby-rust.yaml", { cargo_deny = local.cargo_deny })
 }
 
 module "audit_workflow_node_ruby_rust" {
@@ -107,11 +103,5 @@ module "audit_workflow_node_ruby_rust" {
   base_branch  = "trunk"
   file_path    = ".github/workflows/audit.yaml"
 
-  file_contents = templatefile(
-    "${path.module}/templates/audit-workflow-node-ruby-rust.yaml",
-    {
-      cargo_deny_version = local.cargo_deny_version,
-      release_base_url   = local.cargo_deny_release_base_url,
-    }
-  )
+  file_contents = templatefile("${path.module}/templates/audit-workflow-node-ruby-rust.yaml", { cargo_deny = local.cargo_deny })
 }

--- a/github-org-artichoke/templates/audit-workflow-node-ruby-rust.yaml
+++ b/github-org-artichoke/templates/audit-workflow-node-ruby-rust.yaml
@@ -63,7 +63,7 @@ jobs:
           fi
 
       - name: Setup cargo-deny
-        run: curl -sL "${release_base_url}/${cargo_deny_version}/cargo-deny-${cargo_deny_version}-x86_64-unknown-linux-musl.tar.gz" | sudo tar xvz -C /usr/local/bin/ --strip-components=1
+        run: curl -sL "${cargo_deny.base_url}/${cargo_deny.version}/cargo-deny-${cargo_deny.version}-x86_64-unknown-linux-musl.tar.gz" | sudo tar xvz -C /usr/local/bin/ --strip-components=1
 
       - name: Show cargo-deny version
         run: cargo-deny --version

--- a/github-org-artichoke/templates/audit-workflow-ruby-rust.yaml
+++ b/github-org-artichoke/templates/audit-workflow-ruby-rust.yaml
@@ -49,7 +49,7 @@ jobs:
           fi
 
       - name: Setup cargo-deny
-        run: curl -sL "${release_base_url}/${cargo_deny_version}/cargo-deny-${cargo_deny_version}-x86_64-unknown-linux-musl.tar.gz" | sudo tar xvz -C /usr/local/bin/ --strip-components=1
+        run: curl -sL "${cargo_deny.base_url}/${cargo_deny.version}/cargo-deny-${cargo_deny.version}-x86_64-unknown-linux-musl.tar.gz" | sudo tar xvz -C /usr/local/bin/ --strip-components=1
 
       - name: Show cargo-deny version
         run: cargo-deny --version


### PR DESCRIPTION
Verified this outputs the correct YAML with a plan:

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following
symbols:
  + create

Terraform will perform the following actions:

  # module.audit_workflow_node_ruby_rust["playground"].github_branch.pr_target will be created
  + resource "github_branch" "pr_target" {
      + branch        = "terraform/update-file-.github-workflows-audit.yaml"
      + etag          = (known after apply)
      + id            = (known after apply)
      + ref           = (known after apply)
      + repository    = "playground"
      + sha           = (known after apply)
      + source_branch = "main"
      + source_sha    = "b175c5d41a78a74f6e6a406ad41bea07a1dfa7f8"
    }

  # module.audit_workflow_node_ruby_rust["playground"].github_repository_file.file will be created
  + resource "github_repository_file" "file" {
      + branch              = (known after apply)
      + commit_author       = "artichoke-ci"
      + commit_email        = "ci@artichokeruby.org"
      + commit_message      = <<-EOT
            chore: Update `.github/workflows/audit.yaml` in `artichoke/playground`

            Managed by Terraform.

            ## Contents

            ```
            ---
            name: Audit
            "on":
              push:
                branches:
                  - trunk
              pull_request:
                branches:
                  - trunk
              schedule:
                - cron: "0 0 * * TUE"
            jobs:
              js:
                name: Audit JS Dependencies
                runs-on: ubuntu-latest

                steps:
                  - name: Checkout repository
                    uses: actions/checkout@v2

                  - name: Install Nodejs toolchain
                    run: npm ci

                  - name: npm audit
                    run: npm audit

              ruby:
                name: Audit Ruby Dependencies
                runs-on: ubuntu-latest

                steps:
                  - name: Checkout repository
                    uses: actions/checkout@v2

                  - name: Install Ruby toolchain
                    uses: ruby/setup-ruby@v1
                    with:
                      ruby-version: ".ruby-version"
                      bundler-cache: true

                  - name: bundler-audit
                    run: bundle exec bundle-audit check --update

              rust:
                name: Audit Rust Dependencies
                runs-on: ubuntu-latest

                steps:
                  - name: Checkout repository
                    uses: actions/checkout@v2

                  - name: Install Rust toolchain
                    uses: actions-rs/toolchain@v1
                    with:
                      toolchain: stable
                      profile: minimal
                      override: true

                  - name: Generate Cargo.lock
                    run: |
                      if [[ ! -f "Cargo.lock" ]]; then
                        cargo generate-lockfile --verbose
                      fi

                  - name: Setup cargo-deny
                    run: curl -sL "https://github.com/EmbarkStudios/cargo-deny/releases/download/0.11.3/cargo-deny-0.11.3-x86_64-unknown-linux-musl.tar.gz" | sudo tar xvz -C /usr/local/bin/ --strip-components=1

                  - name: Show cargo-deny version
                    run: cargo-deny --version

                  - name: Run cargo-deny
                    run: cargo-deny --locked check --show-stats
            ```
        EOT
      + commit_sha          = (known after apply)
      + content             = <<-EOT
            ---
            name: Audit
            "on":
              push:
                branches:
                  - trunk
              pull_request:
                branches:
                  - trunk
              schedule:
                - cron: "0 0 * * TUE"
            jobs:
              js:
                name: Audit JS Dependencies
                runs-on: ubuntu-latest

                steps:
                  - name: Checkout repository
                    uses: actions/checkout@v2

                  - name: Install Nodejs toolchain
                    run: npm ci

                  - name: npm audit
                    run: npm audit

              ruby:
                name: Audit Ruby Dependencies
                runs-on: ubuntu-latest

                steps:
                  - name: Checkout repository
                    uses: actions/checkout@v2

                  - name: Install Ruby toolchain
                    uses: ruby/setup-ruby@v1
                    with:
                      ruby-version: ".ruby-version"
                      bundler-cache: true

                  - name: bundler-audit
                    run: bundle exec bundle-audit check --update

              rust:
                name: Audit Rust Dependencies
                runs-on: ubuntu-latest

                steps:
                  - name: Checkout repository
                    uses: actions/checkout@v2

                  - name: Install Rust toolchain
                    uses: actions-rs/toolchain@v1
                    with:
                      toolchain: stable
                      profile: minimal
                      override: true

                  - name: Generate Cargo.lock
                    run: |
                      if [[ ! -f "Cargo.lock" ]]; then
                        cargo generate-lockfile --verbose
                      fi

                  - name: Setup cargo-deny
                    run: curl -sL "https://github.com/EmbarkStudios/cargo-deny/releases/download/0.11.3/cargo-deny-0.11.3-x86_64-unknown-linux-musl.tar.gz" | sudo tar xvz -C /usr/local/bin/ --strip-components=1

                  - name: Show cargo-deny version
                    run: cargo-deny --version

                  - name: Run cargo-deny
                    run: cargo-deny --locked check --show-stats
        EOT
      + file                = ".github/workflows/audit.yaml"
      + id                  = (known after apply)
      + overwrite_on_create = true
      + repository          = "playground"
      + sha                 = (known after apply)
    }

  # module.audit_workflow_ruby_rust["strudel"].github_branch.pr_target will be created
  + resource "github_branch" "pr_target" {
      + branch        = "terraform/update-file-.github-workflows-audit.yaml"
      + etag          = (known after apply)
      + id            = (known after apply)
      + ref           = (known after apply)
      + repository    = "strudel"
      + sha           = (known after apply)
      + source_branch = "main"
      + source_sha    = "fffe33eb510d2f2b585603135661a02d1f54ac95"
    }

  # module.audit_workflow_ruby_rust["strudel"].github_repository_file.file will be created
  + resource "github_repository_file" "file" {
      + branch              = (known after apply)
      + commit_author       = "artichoke-ci"
      + commit_email        = "ci@artichokeruby.org"
      + commit_message      = <<-EOT
            chore: Update `.github/workflows/audit.yaml` in `artichoke/strudel`

            Managed by Terraform.

            ## Contents

            ```
            ---
            name: Audit
            "on":
              push:
                branches:
                  - trunk
              pull_request:
                branches:
                  - trunk
              schedule:
                - cron: "0 0 * * TUE"
            jobs:
              ruby:
                name: Audit Ruby Dependencies
                runs-on: ubuntu-latest

                steps:
                  - name: Checkout repository
                    uses: actions/checkout@v2

                  - name: Install Ruby toolchain
                    uses: ruby/setup-ruby@v1
                    with:
                      ruby-version: ".ruby-version"
                      bundler-cache: true

                  - name: bundler-audit
                    run: bundle exec bundle-audit check --update

              rust:
                name: Audit Rust Dependencies
                runs-on: ubuntu-latest

                steps:
                  - name: Checkout repository
                    uses: actions/checkout@v2

                  - name: Install Rust toolchain
                    uses: actions-rs/toolchain@v1
                    with:
                      toolchain: stable
                      profile: minimal
                      override: true

                  - name: Generate Cargo.lock
                    run: |
                      if [[ ! -f "Cargo.lock" ]]; then
                        cargo generate-lockfile --verbose
                      fi

                  - name: Setup cargo-deny
                    run: curl -sL "https://github.com/EmbarkStudios/cargo-deny/releases/download/0.11.3/cargo-deny-0.11.3-x86_64-unknown-linux-musl.tar.gz" | sudo tar xvz -C /usr/local/bin/ --strip-components=1

                  - name: Show cargo-deny version
                    run: cargo-deny --version

                  - name: Run cargo-deny
                    run: cargo-deny --locked check --show-stats
            ```
        EOT
      + commit_sha          = (known after apply)
      + content             = <<-EOT
            ---
            name: Audit
            "on":
              push:
                branches:
                  - trunk
              pull_request:
                branches:
                  - trunk
              schedule:
                - cron: "0 0 * * TUE"
            jobs:
              ruby:
                name: Audit Ruby Dependencies
                runs-on: ubuntu-latest

                steps:
                  - name: Checkout repository
                    uses: actions/checkout@v2

                  - name: Install Ruby toolchain
                    uses: ruby/setup-ruby@v1
                    with:
                      ruby-version: ".ruby-version"
                      bundler-cache: true

                  - name: bundler-audit
                    run: bundle exec bundle-audit check --update

              rust:
                name: Audit Rust Dependencies
                runs-on: ubuntu-latest

                steps:
                  - name: Checkout repository
                    uses: actions/checkout@v2

                  - name: Install Rust toolchain
                    uses: actions-rs/toolchain@v1
                    with:
                      toolchain: stable
                      profile: minimal
                      override: true

                  - name: Generate Cargo.lock
                    run: |
                      if [[ ! -f "Cargo.lock" ]]; then
                        cargo generate-lockfile --verbose
                      fi

                  - name: Setup cargo-deny
                    run: curl -sL "https://github.com/EmbarkStudios/cargo-deny/releases/download/0.11.3/cargo-deny-0.11.3-x86_64-unknown-linux-musl.tar.gz" | sudo tar xvz -C /usr/local/bin/ --strip-components=1

                  - name: Show cargo-deny version
                    run: cargo-deny --version

                  - name: Run cargo-deny
                    run: cargo-deny --locked check --show-stats
        EOT
      + file                = ".github/workflows/audit.yaml"
      + id                  = (known after apply)
      + overwrite_on_create = true
      + repository          = "strudel"
      + sha                 = (known after apply)
    }

Plan: 4 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + audit_workflow_node_ruby_rust_branches = (known after apply)
  + audit_workflow_ruby_rust_branches      = (known after apply)

─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so Terraform can't guarantee to take exactly these actions if you run
"terraform apply" now.
```