### PR TITLE
Add a Terraform module for archived GitHub repositories

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -26,10 +26,6 @@ namespace :lint do
     TERRAFORM_ENVIRONMENTS.each do |environment|
       sh "terraform -chdir=#{environment} validate"
     end
-    sh 'terraform -chdir=github-org-artichoke validate'
-    sh 'terraform -chdir=github-org-artichokeruby validate'
-    sh 'terraform -chdir=github-org-artichoke-ruby validate'
-    sh 'terraform -chdir=remote-state validate'
   end
 end
 

--- a/github-org-artichoke/archived-repos.tf
+++ b/github-org-artichoke/archived-repos.tf
@@ -1,16 +1,11 @@
-resource "github_repository" "artichoke_ci" {
+module "archived_artichoke_ci" {
+  source = "../modules/archived-repository"
+
   name        = "artichoke-ci"
   description = "🏗 CI infrastructure and images for Artichoke"
 
-  archived   = true
-  visibility = "public"
-
-  has_downloads = true
-  has_issues    = true
-  has_projects  = false
-  has_wiki      = true
-
   delete_branch_on_merge = false
+  has_wiki               = true
 
   topics = [
     "artichoke",
@@ -21,26 +16,18 @@ resource "github_repository" "artichoke_ci" {
     "docker",
     "dockerfile",
   ]
-
-  lifecycle {
-    prevent_destroy = true
-  }
 }
 
-resource "github_repository" "ferrocarril" {
+module "archived_ferrocarril" {
+  source = "../modules/archived-repository"
+
   name         = "ferrocarril"
   description  = "🚆 Experiments to embed Ruby on Rails in Rust with mruby"
   homepage_url = "https://artichoke.github.io/ferrocarril/mruby/"
 
-  archived   = true
-  visibility = "public"
-
-  has_downloads = true
-  has_issues    = true
-  has_projects  = false
-  has_wiki      = true
-
   delete_branch_on_merge = false
+  has_github_pages       = true
+  has_wiki               = true
 
   topics = [
     "artichoke",
@@ -50,63 +37,35 @@ resource "github_repository" "ferrocarril" {
     "sinatra",
     "unicorn",
   ]
-
-  pages {
-    source {
-      branch = "gh-pages"
-      path   = "/"
-    }
-  }
-
-  lifecycle {
-    prevent_destroy = true
-  }
 }
 
-resource "github_repository" "rust_mersenne_twister" {
+module "archived_rust_mersenne_twister" {
+  source = "../modules/archived-repository"
+
   name         = "rust-mersenne-twister"
   description  = "Fork migrated to artichoke/rand_mt"
   homepage_url = "https://github.com/artichoke/rand_mt"
 
-  archived   = true
-  visibility = "public"
-
-  has_downloads = true
-  has_issues    = false
-  has_projects  = false
-  has_wiki      = true
-
   delete_branch_on_merge = true
+  has_github_pages       = true
+  has_issues             = false
+  has_wiki               = true
+
 
   topics = []
-
-  pages {
-    source {
-      branch = "gh-pages"
-      path   = "/"
-    }
-  }
-
-  lifecycle {
-    prevent_destroy = true
-  }
 }
 
-resource "github_repository" "rubyconf2019_artichoke_run" {
+module "archived_rubyconf2019_artichoke_run" {
+  source = "../modules/archived-repository"
+
   name         = "rubyconf2019.artichoke.run"
   description  = "📸 A snapshot of artichoke.run that runs the playground as of RubyConf 2019"
   homepage_url = "https://rubyconf2019.artichoke.run/"
 
-  archived   = true
-  visibility = "public"
-
-  has_downloads = true
-  has_issues    = true
-  has_projects  = false
-  has_wiki      = false
-
   delete_branch_on_merge = true
-  vulnerability_alerts   = false
+  has_github_pages       = true
+
+  github_pages_cname = "rubyconf2019.artichoke.run"
 
   topics = [
     "artichoke",
@@ -119,17 +78,4 @@ resource "github_repository" "rubyconf2019_artichoke_run" {
     "wasm",
     "webassembly",
   ]
-
-  pages {
-    cname = "rubyconf2019.artichoke.run"
-    source {
-      branch = "gh-pages"
-      path   = "/"
-    }
-  }
-
-  lifecycle {
-    prevent_destroy = true
-  }
 }
-

--- a/modules/archived-repository/README.md
+++ b/modules/archived-repository/README.md
@@ -1,0 +1,55 @@
+# Archived Repository
+
+This folder contains a Terraform module to manage archived GitHub repositories.
+
+## Usage
+
+```terraform
+module "archived_ferrocarril" {
+  source = "../modules/archived-repository"
+
+  name         = "ferrocarril"
+  description  = "🚆 Experiments to embed Ruby on Rails in Rust with mruby"
+  homepage_url = "https://artichoke.github.io/ferrocarril/mruby/"
+
+  delete_branch_on_merge = false
+  has_github_pages       = true
+  has_wiki               = true
+
+  topics = [
+    "artichoke",
+    "rack",
+    "ruby",
+    "rust",
+    "sinatra",
+    "unicorn",
+  ]
+}
+```
+
+## Parameters
+
+- `name`: The name of the repository.
+- `description`: A description of the repository.
+- `homepage_url`: A URL of the page describing the project, defaults to `null`.
+- `delete_branch_on_merge`: Automatically delete head branch after a pull
+  request is merged, defaults to `true`.
+- `has_downloads`: Set to true if (deprecated) downloads were enabled on the
+  repository, defaults to `true`.
+- `has_issues`: Set to true to if GitHub Issues were enabled on the repository,
+  defaults to `true`.
+- `has_projects`: Set to true if GitHub Projects were enabled on the repository,
+  defaults to `false`.
+- `has_wiki`: Set to true if GitHub Wiki was enabled on the repository, defaults
+  to `false`.
+- `vulnerability_alerts`: Set to true if a GitHub Pages deploy was enabled on
+  the repository, defaults to `false`.
+- `has_github_pages`: Set to true if a GitHub Pages deploy was enabled on the
+  repository, defaults to `false`.
+- `github_pages_cname`: CNAME record for GitHub Pages deployment, defaults to
+  `null`, only has an effect if `has_github_pages` is `true`.
+- `topics`: The list of topics of the repository.
+
+## Outputs
+
+This module has no outputs.

--- a/modules/archived-repository/main.tf
+++ b/modules/archived-repository/main.tf
@@ -1,0 +1,44 @@
+terraform {
+  required_providers {
+    github = {
+      source  = "integrations/github"
+      version = "~> 4.20"
+    }
+  }
+}
+
+resource "github_repository" "this" {
+  name         = var.name
+  description  = var.description
+  homepage_url = var.homepage_url
+
+  archived   = true
+  visibility = "public"
+
+  has_downloads = var.has_downloads
+  has_issues    = var.has_issues
+  has_projects  = var.has_projects
+  has_wiki      = var.has_wiki
+
+  delete_branch_on_merge = var.delete_branch_on_merge
+  vulnerability_alerts   = var.vulnerability_alerts
+
+  topics = var.topics
+
+  dynamic "pages" {
+    for_each = range(var.has_github_pages ? 1 : 0)
+
+    content {
+      cname = var.github_pages_cname
+
+      source {
+        branch = "gh-pages"
+        path   = "/"
+      }
+    }
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}

--- a/modules/archived-repository/variables.tf
+++ b/modules/archived-repository/variables.tf
@@ -1,0 +1,68 @@
+variable "name" {
+  description = "The name of the repository"
+  type        = string
+}
+
+variable "description" {
+  description = "A description of the repository"
+  type        = string
+}
+
+variable "homepage_url" {
+  description = "A URL of the page describing the project"
+  default     = null
+  type        = string
+}
+
+variable "delete_branch_on_merge" {
+  description = "Automatically delete head branch after a pull request is merged"
+  default     = true
+  type        = bool
+}
+
+variable "has_downloads" {
+  description = "Set to true if (deprecated) downloads were enabled on the repository"
+  default     = true
+  type        = bool
+}
+
+variable "has_issues" {
+  description = "Set to true to if GitHub Issues were enabled on the repository"
+  default     = true
+  type        = bool
+}
+
+variable "has_projects" {
+  description = "Set to true if GitHub Projects were enabled on the repository"
+  default     = false
+  type        = bool
+}
+
+variable "has_wiki" {
+  description = "Set to true if GitHub Wiki was enabled on the repository"
+  default     = false
+  type        = bool
+}
+
+variable "vulnerability_alerts" {
+  description = "Set to true to enable security alerts for vulnerable dependencies"
+  default     = false
+  type        = bool
+}
+
+variable "has_github_pages" {
+  description = "Set to true if a GitHub Pages deploy was enabled on the repository"
+  default     = false
+  type        = bool
+}
+
+variable "github_pages_cname" {
+  description = "CNAME record for GitHub Pages deployment"
+  default     = null
+  type        = string
+}
+
+variable "topics" {
+  description = "The list of topics of the repository"
+  type        = list(string)
+}


### PR DESCRIPTION
Migrate `github_repository` items in the `github-org-artichoke` environment.