### PR TITLE
Add Terraform module for creating AWS KMS keys and aliases

### DIFF
--- a/modules/kms-key/README.md
+++ b/modules/kms-key/README.md
@@ -1,0 +1,28 @@
+# KMS Key
+
+This folder contains a Terraform module to provision an AWS KMS key with key
+rotation and an alias.
+
+## Usage
+
+```terraform
+module "remote_state" {
+  source = "../modules/kms-key"
+
+  description       = "Key for encrypting remote state bucket contents"
+  alias_name_prefix = "s3-remote-state-"
+}
+```
+
+## Parameters
+
+- `description`: The description of the KMS key.
+- `alias_name_prefix`: A prefix for the alias name. This variable must be
+  non-empty and must not start with `alias/`.
+
+## Outputs
+
+- `key_arn`: The ARN of the created KMS key.
+- `key_id`: The ID of the created KMS key.
+- `alias_arn`: The ARN of the created KMS key alias.
+- `alias_name`: The name of the created KMS key alias.

--- a/modules/kms-key/main.tf
+++ b/modules/kms-key/main.tf
@@ -1,0 +1,9 @@
+resource "aws_kms_key" "this" {
+  description         = var.description
+  enable_key_rotation = true
+}
+
+resource "aws_kms_alias" "this" {
+  name_prefix   = "alias/${var.alias_name_prefix}"
+  target_key_id = aws_kms_key.this.key_id
+}

--- a/modules/kms-key/outputs.tf
+++ b/modules/kms-key/outputs.tf
@@ -1,0 +1,19 @@
+output "key_arn" {
+  description = "The ARN of the KMS key"
+  value       = aws_kms_key.this.arn
+}
+
+output "key_id" {
+  description = "The ID of the KMS key"
+  value       = aws_kms_key.this.key_id
+}
+
+output "alias_arn" {
+  description = "The ARN of the KMS key alias"
+  value       = aws_kms_alias.this.arn
+}
+
+output "alias_name" {
+  description = "The name of the KMS key alias"
+  value       = aws_kms_alias.this.name
+}

--- a/modules/kms-key/variables.tf
+++ b/modules/kms-key/variables.tf
@@ -1,0 +1,19 @@
+variable "description" {
+  description = "The description of the key as viewed in AWS console"
+  type        = string
+}
+
+variable "alias_name_prefix" {
+  description = "A prefix for the KMS key alias. This variable must be non-empty and must not start with `alias/`."
+  type        = string
+
+  validation {
+    condition     = substr(var.alias_name_prefix, 0, 6) != "alias/"
+    error_message = "The alias_name_prefix value must not start with `alias/`."
+  }
+
+  validation {
+    condition     = length(var.alias_name_prefix) > 0
+    error_message = "The alias_name_prefix value must not be empty."
+  }
+}

--- a/remote-state/main.tf
+++ b/remote-state/main.tf
@@ -21,8 +21,11 @@ module "remote_state" {
   access_logs_bucket = module.remote_state_access_logs.name
 }
 
-resource "aws_kms_key" "terraform_statelock" {
-  enable_key_rotation = true
+module "dynamo_statelock_kms" {
+  source = "../modules/kms-key"
+
+  description       = "Key for encrypting remote state DynamoDB table"
+  alias_name_prefix = "dynamodb-remote-state-"
 }
 
 resource "aws_dynamodb_table" "terraform_statelock" {
@@ -37,7 +40,7 @@ resource "aws_dynamodb_table" "terraform_statelock" {
 
   server_side_encryption {
     enabled     = true
-    kms_key_arn = aws_kms_key.terraform_statelock.arn
+    kms_key_arn = module.dynamo_statelock_kms.key_arn
   }
 
   attribute {


### PR DESCRIPTION
Migrate remote-state environment to use KMS key module.

This change is applied after doing some remote state moves:

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following
symbols:
  + create
  ~ update in-place

Terraform will perform the following actions:

  # module.dynamo_statelock_kms.aws_kms_alias.this will be created
  + resource "aws_kms_alias" "this" {
      + arn            = (known after apply)
      + id             = (known after apply)
      + name           = (known after apply)
      + name_prefix    = "alias/dynamodb-remote-state-"
      + target_key_arn = (known after apply)
      + target_key_id  = "78a66197-0228-4a2b-a19c-d691a0b4e0f3"
    }

  # module.dynamo_statelock_kms.aws_kms_key.this will be updated in-place
  ~ resource "aws_kms_key" "this" {
      + description                        = "Key for encrypting remote state DynamoDB table"
        id                                 = "78a66197-0228-4a2b-a19c-d691a0b4e0f3"
        tags                               = {}
        # (10 unchanged attributes hidden)
    }

Plan: 1 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

module.dynamo_statelock_kms.aws_kms_key.this: Modifying... [id=78a66197-0228-4a2b-a19c-d691a0b4e0f3]
module.dynamo_statelock_kms.aws_kms_key.this: Modifications complete after 9s [id=78a66197-0228-4a2b-a19c-d691a0b4e0f3]
module.dynamo_statelock_kms.aws_kms_alias.this: Creating...
module.dynamo_statelock_kms.aws_kms_alias.this: Creation complete after 0s [id=alias/dynamodb-remote-state-20220218194644812100000001]

Apply complete! Resources: 1 added, 1 changed, 0 destroyed.
```