### PR TITLE
Use non-default 'aws/s3' KMS keys for encrypting S3 buckets

### DIFF
--- a/modules/access-logs-s3-bucket/main.tf
+++ b/modules/access-logs-s3-bucket/main.tf
@@ -66,12 +66,20 @@ resource "aws_s3_bucket_public_access_block" "this" {
   }
 }
 
+module "kms_key" {
+  source = "../kms-key"
+
+  description       = "Key for encrypting ${var.bucket} S3 bucket"
+  alias_name_prefix = "s3-sse-${var.bucket}-"
+}
+
 resource "aws_s3_bucket_server_side_encryption_configuration" "this" {
   bucket = aws_s3_bucket.this.id
 
   rule {
     apply_server_side_encryption_by_default {
-      sse_algorithm = "aws:kms"
+      kms_master_key_id = module.kms_key.key_arn
+      sse_algorithm     = "aws:kms"
     }
   }
 

--- a/modules/private-s3-bucket/main.tf
+++ b/modules/private-s3-bucket/main.tf
@@ -40,12 +40,20 @@ resource "aws_s3_bucket_public_access_block" "this" {
   }
 }
 
+module "kms_key" {
+  source = "../kms-key"
+
+  description       = "Key for encrypting ${var.bucket} S3 bucket"
+  alias_name_prefix = "s3-sse-${var.bucket}-"
+}
+
 resource "aws_s3_bucket_server_side_encryption_configuration" "this" {
   bucket = aws_s3_bucket.this.id
 
   rule {
     apply_server_side_encryption_by_default {
-      sse_algorithm = "aws:kms"
+      kms_master_key_id = module.kms_key.key_arn
+      sse_algorithm     = "aws:kms"
     }
   }
 


### PR DESCRIPTION
This change made easy by the new `kms-key` module introduced in #225.

This change is applied:

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following
symbols:
  + create
  ~ update in-place

Terraform will perform the following actions:

  # module.remote_state.aws_s3_bucket_server_side_encryption_configuration.this will be updated in-place
  ~ resource "aws_s3_bucket_server_side_encryption_configuration" "this" {
        id     = "artichoke-forge-project-infrastructure-terraform-state"
        # (1 unchanged attribute hidden)

      - rule {
          - bucket_key_enabled = false -> null

          - apply_server_side_encryption_by_default {
              - sse_algorithm = "aws:kms" -> null
            }
        }
      + rule {
          + apply_server_side_encryption_by_default {
              + kms_master_key_id = (known after apply)
              + sse_algorithm     = "aws:kms"
            }
        }
    }

  # module.remote_state_access_logs.aws_s3_bucket_server_side_encryption_configuration.this will be updated in-place
  ~ resource "aws_s3_bucket_server_side_encryption_configuration" "this" {
        id     = "artichoke-forge-project-infrastructure-terraform-state-logs"
        # (1 unchanged attribute hidden)

      - rule {
          - bucket_key_enabled = false -> null

          - apply_server_side_encryption_by_default {
              - sse_algorithm = "aws:kms" -> null
            }
        }
      + rule {
          + apply_server_side_encryption_by_default {
              + kms_master_key_id = (known after apply)
              + sse_algorithm     = "aws:kms"
            }
        }
    }

  # module.remote_state.module.kms_key.aws_kms_alias.this will be created
  + resource "aws_kms_alias" "this" {
      + arn            = (known after apply)
      + id             = (known after apply)
      + name           = (known after apply)
      + name_prefix    = "alias/s3-sse-artichoke-forge-project-infrastructure-terraform-state-"
      + target_key_arn = (known after apply)
      + target_key_id  = (known after apply)
    }

  # module.remote_state.module.kms_key.aws_kms_key.this will be created
  + resource "aws_kms_key" "this" {
      + arn                                = (known after apply)
      + bypass_policy_lockout_safety_check = false
      + customer_master_key_spec           = "SYMMETRIC_DEFAULT"
      + description                        = "Key for encrypting artichoke-forge-project-infrastructure-terraform-state S3 bucket"
      + enable_key_rotation                = true
      + id                                 = (known after apply)
      + is_enabled                         = true
      + key_id                             = (known after apply)
      + key_usage                          = "ENCRYPT_DECRYPT"
      + multi_region                       = (known after apply)
      + policy                             = (known after apply)
      + tags_all                           = {
          + "managed_by" = "terraform"
          + "project"    = "remote-state"
        }
    }

  # module.remote_state_access_logs.module.kms_key.aws_kms_alias.this will be created
  + resource "aws_kms_alias" "this" {
      + arn            = (known after apply)
      + id             = (known after apply)
      + name           = (known after apply)
      + name_prefix    = "alias/s3-sse-artichoke-forge-project-infrastructure-terraform-state-logs-"
      + target_key_arn = (known after apply)
      + target_key_id  = (known after apply)
    }

  # module.remote_state_access_logs.module.kms_key.aws_kms_key.this will be created
  + resource "aws_kms_key" "this" {
      + arn                                = (known after apply)
      + bypass_policy_lockout_safety_check = false
      + customer_master_key_spec           = "SYMMETRIC_DEFAULT"
      + description                        = "Key for encrypting artichoke-forge-project-infrastructure-terraform-state-logs S3 bucket"
      + enable_key_rotation                = true
      + id                                 = (known after apply)
      + is_enabled                         = true
      + key_id                             = (known after apply)
      + key_usage                          = "ENCRYPT_DECRYPT"
      + multi_region                       = (known after apply)
      + policy                             = (known after apply)
      + tags_all                           = {
          + "managed_by" = "terraform"
          + "project"    = "remote-state"
        }
    }

Plan: 4 to add, 2 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

module.remote_state_access_logs.module.kms_key.aws_kms_key.this: Creating...
module.remote_state.module.kms_key.aws_kms_key.this: Creating...
module.remote_state_access_logs.module.kms_key.aws_kms_key.this: Creation complete after 9s [id=a8dcdc6f-e941-4e56-988c-5712caaa5696]
module.remote_state.module.kms_key.aws_kms_key.this: Creation complete after 9s [id=c553558a-c955-4352-843d-9816db190978]
module.remote_state.module.kms_key.aws_kms_alias.this: Creating...
module.remote_state_access_logs.module.kms_key.aws_kms_alias.this: Creating...
module.remote_state_access_logs.aws_s3_bucket_server_side_encryption_configuration.this: Modifying... [id=artichoke-forge-project-infrastructure-terraform-state-logs]
module.remote_state.aws_s3_bucket_server_side_encryption_configuration.this: Modifying... [id=artichoke-forge-project-infrastructure-terraform-state]
module.remote_state_access_logs.module.kms_key.aws_kms_alias.this: Creation complete after 0s [id=alias/s3-sse-artichoke-forge-project-infrastructure-terraform-state-logs-20220219020349796800000001]
module.remote_state.module.kms_key.aws_kms_alias.this: Creation complete after 0s [id=alias/s3-sse-artichoke-forge-project-infrastructure-terraform-state-20220219020349796800000002]
module.remote_state.aws_s3_bucket_server_side_encryption_configuration.this: Modifications complete after 0s [id=artichoke-forge-project-infrastructure-terraform-state]
module.remote_state_access_logs.aws_s3_bucket_server_side_encryption_configuration.this: Modifications complete after 0s [id=artichoke-forge-project-infrastructure-terraform-state-logs]

Apply complete! Resources: 4 added, 2 changed, 0 destroyed.
```