### PR TITLE
Move GitHub OIDC connect provider to dedicated module

### DIFF
--- a/aws/main.tf
+++ b/aws/main.tf
@@ -8,11 +8,16 @@ terraform {
   }
 }
 
+module "github_actions_oidc_provider" {
+  source = "../modules/github-actions-oidc-provider"
+}
+
 module "github_actions_project_infrastructure_assume_role" {
   source = "../modules/github-actions-s3-bucket-read-only-access"
 
-  github_organization = "artichoke"
-  github_repository   = "project-infrastructure"
+  github_oidc_provider_arn = module.github_actions_oidc_provider.arn
+  github_organization      = "artichoke"
+  github_repository        = "project-infrastructure"
 
   s3_bucket_name = "artichoke-forge-project-infrastructure-terraform-state"
 }

--- a/modules/github-actions-oidc-provider/README.md
+++ b/modules/github-actions-oidc-provider/README.md
@@ -1,0 +1,24 @@
+# GitHub OIDC Provider
+
+This folder contains a Terraform module to provision a GitHub Actions OpenID
+Connect provider in AWS. This module should only be instantiated once per AWS
+account since OpenID Connect providers must be globally unique per account.
+
+The provider is for the `https://token.actions.githubusercontent.com` identity
+provider.
+
+## Usage
+
+```terraform
+module "github_actions_oidc_provider" {
+  source = "../modules/github-actions-oidc-provider"
+}
+```
+
+## Parameters
+
+This action has no parameters.
+
+## Outputs
+
+- `arn`: The ARN for the created OpenID Connect provider.

--- a/modules/github-actions-oidc-provider/main.tf
+++ b/modules/github-actions-oidc-provider/main.tf
@@ -1,0 +1,14 @@
+# GitHub OpenID Connect with cloud providers
+#
+# https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-cloud-providers
+
+resource "aws_iam_openid_connect_provider" "github" {
+  url = "https://token.actions.githubusercontent.com"
+
+  client_id_list = [
+    "sts.amazonaws.com"
+  ]
+
+  # https://github.blog/changelog/2022-01-13-github-actions-update-on-oidc-based-deployments-to-aws/
+  thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1"]
+}

--- a/modules/github-actions-oidc-provider/outputs.tf
+++ b/modules/github-actions-oidc-provider/outputs.tf
@@ -1,0 +1,4 @@
+output "arn" {
+  value       = aws_iam_openid_connect_provider.github.arn
+  description = "This is the ARN of the GitHub OpenID Connect provider"
+}

--- a/modules/github-actions-s3-bucket-read-only-access/README.md
+++ b/modules/github-actions-s3-bucket-read-only-access/README.md
@@ -1,17 +1,22 @@
 # GitHub OIDC S3 Bucket Read-Only Access
 
-This folder contains a Terraform module to provision an OpenID Connect provider
-in AWS and an IAM role to allow GitHub Actions in a specific repository read
-access to an S3 bucket.
+This folder contains a Terraform module to provision an IAM role to allow GitHub
+Actions in a specific repository read access to an S3 bucket using an existing
+GitHub OpenID Connect provider.
 
 ## Usage
 
 ```terraform
+module "github_actions_oidc_provider" {
+  source = "../modules/github-actions-oidc-provider"
+}
+
 module "github_actions_project_infrastructure_assume_role" {
   source = "../modules/github-actions-s3-bucket-read-only-access"
 
-  github_organization = "artichoke"
-  github_repository   = "project-infrastructure"
+  github_oidc_provider_arn = module.github_actions_oidc_provider.arn
+  github_organization      = "artichoke"
+  github_repository        = "project-infrastructure"
 
   s3_bucket_name = "artichoke-forge-project-infrastructure-terraform-state"
 }
@@ -19,6 +24,8 @@ module "github_actions_project_infrastructure_assume_role" {
 
 ## Parameters
 
+- `github_oidc_provider_arn`: AWS IAM OIDC provider ARN for
+  `token.actions.githubusercontent.com`.
 - `github_organization`: The name of the GitHub organization that the target
   repository is a part of. For example, in
   <https://github.com/artichoke/project-infrastructure>, the GitHub organization
@@ -31,6 +38,9 @@ module "github_actions_project_infrastructure_assume_role" {
   not its ARN.
 
 ## Outputs
+
+- `role_arn`: The ARN of the role that can be assumed in GitHub Actions to
+  access AWS resources.
 
 This module will output the name of a role that can be used with AWS GitHub
 Actions for authenticating to AWS. For example:

--- a/modules/github-actions-s3-bucket-read-only-access/main.tf
+++ b/modules/github-actions-s3-bucket-read-only-access/main.tf
@@ -2,17 +2,6 @@
 #
 # https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-cloud-providers
 
-resource "aws_iam_openid_connect_provider" "github" {
-  url = "https://token.actions.githubusercontent.com"
-
-  client_id_list = [
-    "sts.amazonaws.com"
-  ]
-
-  # https://github.blog/changelog/2022-01-13-github-actions-update-on-oidc-based-deployments-to-aws/
-  thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1"]
-}
-
 data "aws_iam_policy_document" "github_allow" {
   statement {
     effect  = "Allow"
@@ -20,7 +9,7 @@ data "aws_iam_policy_document" "github_allow" {
 
     principals {
       type        = "Federated"
-      identifiers = [aws_iam_openid_connect_provider.github.arn]
+      identifiers = [var.github_oidc_provider_arn]
     }
 
     condition {

--- a/modules/github-actions-s3-bucket-read-only-access/variables.tf
+++ b/modules/github-actions-s3-bucket-read-only-access/variables.tf
@@ -1,3 +1,8 @@
+variable "github_oidc_provider_arn" {
+  description = "AWS IAM OIDC provider ARN for token.actions.githubusercontent.com"
+  type        = string
+}
+
 variable "github_organization" {
   description = "The GitHub organization to grant access to"
   type        = string


### PR DESCRIPTION
There can only be one of these per account.

Prepare for making additional roles for other GitHub Actions workflows.