### PR TITLE
Provision S3 bucket and IAM roles for repo backups to be invoked from GitHub Actions

### DIFF
--- a/aws/main.tf
+++ b/aws/main.tf
@@ -31,13 +31,13 @@ module "github_actions_project_infrastructure_assume_role" {
 module "repo_backups_access_logs" {
   source = "../modules/access-logs-s3-bucket"
 
-  bucket = "artichoke-forge-github-backups-logs"
+  bucket = "artichoke-forge-github-backups-logs-${var.region}"
 }
 
 module "repo_backups" {
-  source = "../modules/private-s3-bucket"
+  source = "../modules/private-archive-s3-bucket"
 
-  bucket             = "artichoke-forge-github-backups"
+  bucket             = "artichoke-forge-github-backups-${var.region}"
   access_logs_bucket = module.repo_backups_access_logs.name
 }
 

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -8,6 +8,12 @@ terraform {
   }
 }
 
+locals {
+  backed_up_repositories = [
+    "project-infrastructure",
+  ]
+}
+
 module "github_actions_oidc_provider" {
   source = "../modules/github-actions-oidc-provider"
 }
@@ -20,4 +26,28 @@ module "github_actions_project_infrastructure_assume_role" {
   github_repository        = "project-infrastructure"
 
   s3_bucket_name = "artichoke-forge-project-infrastructure-terraform-state"
+}
+
+module "repo_backups_access_logs" {
+  source = "../modules/access-logs-s3-bucket"
+
+  bucket = "artichoke-forge-github-backups-logs"
+}
+
+module "repo_backups" {
+  source = "../modules/private-s3-bucket"
+
+  bucket             = "artichoke-forge-github-backups"
+  access_logs_bucket = module.repo_backups_access_logs.name
+}
+
+module "github_actions_s3_backups_assume_role" {
+  source   = "../modules/github-actions-s3-repo-backup-access"
+  for_each = toset(local.backed_up_repositories)
+
+  github_oidc_provider_arn = module.github_actions_oidc_provider.arn
+  github_organization      = "artichoke"
+  github_repository        = each.value
+
+  s3_bucket_name = module.repo_backups.name
 }

--- a/aws/outputs.tf
+++ b/aws/outputs.tf
@@ -1,4 +1,9 @@
 output "github_actions_project_infrastructure_assume_role_arn" {
-  value       = module.github_actions_project_infrastructure_assume_role.role_arn
   description = "This is the ARN of the role that can be assumed in GitHub Actions to access AWS resources"
+  value       = module.github_actions_project_infrastructure_assume_role.role_arn
+}
+
+output "github_actions_s3_backup_assume_role_arn" {
+  description = "This is the ARN of the role that can be assumed in GitHub Actions to access AWS resources"
+  value       = {for repo, m in module.github_actions_s3_backups_assume_role : repo => m.role_arn}
 }

--- a/aws/outputs.tf
+++ b/aws/outputs.tf
@@ -5,5 +5,5 @@ output "github_actions_project_infrastructure_assume_role_arn" {
 
 output "github_actions_s3_backup_assume_role_arn" {
   description = "This is the ARN of the role that can be assumed in GitHub Actions to access AWS resources"
-  value       = {for repo, m in module.github_actions_s3_backups_assume_role : repo => m.role_arn}
+  value       = { for repo, m in module.github_actions_s3_backups_assume_role : repo => m.role_arn }
 }

--- a/modules/github-actions-s3-repo-backup-access/README.md
+++ b/modules/github-actions-s3-repo-backup-access/README.md
@@ -1,0 +1,57 @@
+# GitHub OIDC S3 Bucket Repository Backup Access
+
+This folder contains a Terraform module to provision an IAM role to allow GitHub
+Actions in a specific repository put to an S3 bucket for repository backups
+using an existing GitHub OpenID Connect provider.
+
+The given repository is given `s3:PutObject` permission to a folder with the
+same name as the repository in the given S3 bucket.
+
+## Usage
+
+```terraform
+module "github_actions_oidc_provider" {
+  source = "../modules/github-actions-oidc-provider"
+}
+
+module "github_actions_project_infrastructure_assume_role" {
+  source = "../modules/github-actions-s3-repo-backup-access"
+
+  github_oidc_provider_arn = module.github_actions_oidc_provider.arn
+  github_organization      = "artichoke"
+  github_repository        = "project-infrastructure"
+
+  s3_bucket_name = "artichoke-forge-github-backup"
+}
+```
+
+## Parameters
+
+- `github_oidc_provider_arn`: AWS IAM OIDC provider ARN for
+  `token.actions.githubusercontent.com`.
+- `github_organization`: The name of the GitHub organization that the target
+  repository is a part of. For example, in
+  <https://github.com/artichoke/project-infrastructure>, the GitHub organization
+  is `artichoke`.
+- `github_repository`: The name of the repository to grant read access to. For
+  example, in <https://github.com/artichoke/project-infrastructure>, the GitHub
+  repository is `project-infrastructure`.
+- `s3_bucket_name`: The name of the S3 bucket to which the target repository
+  should be granted access. This is only the name of the S3 bucket; not its ARN.
+
+## Outputs
+
+- `role_arn`: The ARN of the role that can be assumed in GitHub Actions to
+  access AWS resources.
+
+This module will output the name of a role that can be used with AWS GitHub
+Actions for authenticating to AWS. For example:
+
+```yaml
+- name: Configure AWS Credentials
+  uses: aws-actions/configure-aws-credentials@master
+  with:
+    aws-region: us-west-2
+    role-to-assume: arn:aws:iam::447522982029:role/github-actions-artichoke-project-infrastructure-role
+    role-session-name: GitHubActionsSession@tfsec-terraform
+```

--- a/modules/github-actions-s3-repo-backup-access/main.tf
+++ b/modules/github-actions-s3-repo-backup-access/main.tf
@@ -40,7 +40,7 @@ data "aws_iam_policy_document" "backup" {
     ]
 
     condition {
-      test     = "StringLike"
+      test     = "StringEquals"
       variable = "s3:prefix"
       values   = ["${data.aws_s3_bucket.bucket.id}/"]
     }

--- a/modules/github-actions-s3-repo-backup-access/main.tf
+++ b/modules/github-actions-s3-repo-backup-access/main.tf
@@ -1,0 +1,60 @@
+# GitHub OpenID Connect with cloud providers
+#
+# https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-cloud-providers
+
+data "aws_iam_policy_document" "github_allow" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [var.github_oidc_provider_arn]
+    }
+
+    condition {
+      test     = "StringLike"
+      variable = "token.actions.githubusercontent.com:sub"
+      values   = ["repo:${var.github_organization}/${var.github_repository}:*"]
+    }
+  }
+}
+
+resource "aws_iam_role" "github_role" {
+  name_prefix        = "gha-${var.github_repository}-s3-backup-"
+  assume_role_policy = data.aws_iam_policy_document.github_allow.json
+}
+
+data "aws_s3_bucket" "bucket" {
+  bucket = var.s3_bucket_name
+}
+
+data "aws_iam_policy_document" "backup" {
+  statement {
+    sid = 1
+
+    effect = "Allow"
+
+    actions = [
+      "s3:PutObject"
+    ]
+
+    condition {
+      test     = "StringLike"
+      variable = "s3:prefix"
+      values   = ["${data.aws_s3_bucket.bucket.id}/"]
+    }
+
+    resources = ["${data.aws_s3_bucket.bucket.arn}/*"]
+  }
+}
+
+resource "aws_iam_policy" "backup" {
+  name_prefix = "${var.github_organization}-${var.github_repository}-repo-s3-backup-"
+  policy      = data.aws_iam_policy_document.backup.json
+}
+
+resource "aws_iam_role_policy_attachment" "backup" {
+  role       = aws_iam_role.github_role.name
+  policy_arn = aws_iam_policy.backup.arn
+}

--- a/modules/github-actions-s3-repo-backup-access/outputs.tf
+++ b/modules/github-actions-s3-repo-backup-access/outputs.tf
@@ -1,0 +1,4 @@
+output "role_arn" {
+  value       = aws_iam_role.github_role.arn
+  description = "This is the ARN of the role that can be assumed in GitHub Actions to access AWS resources"
+}

--- a/modules/github-actions-s3-repo-backup-access/variables.tf
+++ b/modules/github-actions-s3-repo-backup-access/variables.tf
@@ -1,0 +1,19 @@
+variable "github_oidc_provider_arn" {
+  description = "AWS IAM OIDC provider ARN for token.actions.githubusercontent.com"
+  type        = string
+}
+
+variable "github_organization" {
+  description = "The GitHub organization to grant access to"
+  type        = string
+}
+
+variable "github_repository" {
+  description = "The GitHub repository in the organization to grant access to"
+  type        = string
+}
+
+variable "s3_bucket_name" {
+  description = "The S3 bucket to grant access to"
+  type        = string
+}

--- a/modules/private-archive-s3-bucket/README.md
+++ b/modules/private-archive-s3-bucket/README.md
@@ -1,0 +1,33 @@
+# Private S3 Bucket
+
+This folder contains a Terraform module to provision an AWS S3 bucket with no
+public access and access logging enabled. This bucket has versioning and
+lifecycle policies meant for long-term, append-only archival storage.
+
+## Usage
+
+```terraform
+module "access_logs" {
+  source = "../modules/access-logs-s3-bucket"
+
+  bucket = "artichoke-forge-backups-logs"
+}
+
+module "bucket" {
+  source = "../modules/private-archive-s3-bucket"
+
+  bucket = "artichoke-forge-backups"
+  access_logs_bucket = module.access_logs.name
+}
+```
+
+## Parameters
+
+- `bucket`: The name of the bucket to create.
+- `access_logs_bucket`: The name of the bucket to use as an access logs
+  destination.
+
+## Outputs
+
+- `arn`: The ARN of the created bucket.
+- `name`: The name of the created bucket.

--- a/modules/private-archive-s3-bucket/main.tf
+++ b/modules/private-archive-s3-bucket/main.tf
@@ -1,0 +1,99 @@
+resource "aws_s3_bucket" "this" {
+  bucket = var.bucket
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_s3_bucket_acl" "this" {
+  bucket = aws_s3_bucket.this.id
+  acl    = "private"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  rule {
+    id     = "archive"
+    status = "Enabled"
+
+    transition {
+      days          = 30
+      storage_class = "GLACIER_IR"
+    }
+
+    noncurrent_version_transition {
+      noncurrent_days = 30
+      storage_class   = "GLACIER"
+    }
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_s3_bucket_logging" "this" {
+  bucket        = aws_s3_bucket.this.id
+  target_bucket = var.access_logs_bucket
+  target_prefix = "v2/${var.bucket}/"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  block_public_acls   = true
+  block_public_policy = true
+
+  ignore_public_acls = true
+
+  restrict_public_buckets = true
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+module "kms_key" {
+  source = "../kms-key"
+
+  description       = "Key for encrypting ${var.bucket} S3 bucket"
+  alias_name_prefix = "s3-sse-${var.bucket}-"
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      kms_master_key_id = module.kms_key.key_arn
+      sse_algorithm     = "aws:kms"
+    }
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_s3_bucket_versioning" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  versioning_configuration {
+    status     = "Enabled"
+    mfa_delete = "Disabled"
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}

--- a/modules/private-archive-s3-bucket/outputs.tf
+++ b/modules/private-archive-s3-bucket/outputs.tf
@@ -1,0 +1,9 @@
+output "name" {
+  description = "The name of the S3 bucket"
+  value       = aws_s3_bucket.this.id
+}
+
+output "arn" {
+  description = "The ARN of the S3 bucket"
+  value       = aws_s3_bucket.this.arn
+}

--- a/modules/private-archive-s3-bucket/variables.tf
+++ b/modules/private-archive-s3-bucket/variables.tf
@@ -1,0 +1,9 @@
+variable "bucket" {
+  description = "The name of the bucket"
+  type        = string
+}
+
+variable "access_logs_bucket" {
+  description = "The name of the bucket to use as the destination for access logs"
+  type        = string
+}

--- a/modules/private-archive-s3-bucket/versions.tf
+++ b/modules/private-archive-s3-bucket/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+
+  required_version = "~> 1.0"
+}

--- a/modules/private-s3-bucket/README.md
+++ b/modules/private-s3-bucket/README.md
@@ -13,7 +13,7 @@ module "access_logs" {
 }
 
 module "bucket" {
-  source = "../modules/access-logs-s3-bucket"
+  source = "../modules/private-s3-bucket"
 
   bucket = "artichoke-forge-project-infrastructure-terraform-state"
   access_logs_bucket = module.access_logs.name


### PR DESCRIPTION
This is my take on the GitHub backup strategy outlined here: https://www.marcolancini.it/2021/blog-github-backups-with-ecs/.

This PR creates an archival S3 bucket and provisions repo-specific IAM roles that grant `s3:PutObject` access to repo-specific directories.

This PR creates the IAM roles for this repository and a followup PR will try to get the action working. The goal is to have GitHub template out a GitHub Actions workflow using the `aws` environment as a remote state source to grab the IAM roles for each repository.