### PR TITLE
Add custom, more permissive KMS key policy in `kms-key` module

### DIFF
--- a/modules/kms-key/README.md
+++ b/modules/kms-key/README.md
@@ -11,6 +11,8 @@ module "remote_state" {
 
   description       = "Key for encrypting remote state bucket contents"
   alias_name_prefix = "s3-remote-state-"
+
+  roles_with_key_access = []
 }
 ```
 
@@ -19,6 +21,7 @@ module "remote_state" {
 - `description`: The description of the KMS key.
 - `alias_name_prefix`: A prefix for the alias name. This variable must be
   non-empty and must not start with `alias/`.
+- `roles_with_key_access`: IAM roles to grant access to this KMS key.
 
 ## Outputs
 

--- a/modules/kms-key/main.tf
+++ b/modules/kms-key/main.tf
@@ -1,5 +1,85 @@
+data "aws_caller_identity" "current" {}
+
+data "aws_iam_policy_document" "key_policy" {
+  statement {
+    sid       = "Enable IAM User Permissions"
+    effect    = "Allow"
+    actions   = ["kms:*"]
+    resources = ["*"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+    }
+  }
+
+  statement {
+    sid       = "Allow access for Key Administrators"
+    effect    = "Allow"
+    actions   = ["kms:*"]
+    resources = ["*"]
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-service-role/support.amazonaws.com/AWSServiceRoleForSupport",
+        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-service-role/trustedadvisor.amazonaws.com/AWSServiceRoleForTrustedAdvisor"
+      ]
+    }
+  }
+
+  statement {
+    sid    = "Allow use of the key"
+    effect = "Allow"
+    actions = [
+      "kms:Encrypt",
+      "kms:Decrypt",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:DescribeKey"
+    ]
+    resources = ["*"]
+
+    principals {
+      type = "AWS"
+      identifiers = concat(
+        [
+          "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-service-role/support.amazonaws.com/AWSServiceRoleForSupport",
+          "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-service-role/trustedadvisor.amazonaws.com/AWSServiceRoleForTrustedAdvisor"
+        ],
+        var.roles_with_key_access
+      )
+    }
+  }
+
+  statement {
+    sid    = "Allow attachment of persistent resources"
+    effect = "Allow"
+    actions = [
+      "kms:CreateGrant",
+      "kms:ListGrants",
+      "kms:RevokeGrant"
+    ]
+    resources = ["*"]
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-service-role/support.amazonaws.com/AWSServiceRoleForSupport",
+        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-service-role/trustedadvisor.amazonaws.com/AWSServiceRoleForTrustedAdvisor"
+      ]
+    }
+
+    condition {
+      test     = "Bool"
+      variable = "kms:GrantIsForAWSResource"
+      values   = ["true"]
+    }
+  }
+}
 resource "aws_kms_key" "this" {
   description         = var.description
+  policy              = data.aws_iam_policy_document.key_policy.json
   enable_key_rotation = true
 }
 

--- a/modules/kms-key/variables.tf
+++ b/modules/kms-key/variables.tf
@@ -17,3 +17,9 @@ variable "alias_name_prefix" {
     error_message = "The alias_name_prefix value must not be empty."
   }
 }
+
+variable "roles_with_key_access" {
+  description = "IAM roles to grant access to this KMS key"
+  default     = []
+  type        = list(string)
+}


### PR DESCRIPTION
Add a non-default KMS key policy in the `kms-key` module. This key
policy contains the same stanzas as the default key policy but also
allows specifiying a list of roles that should always have acceess to
the KMS key for encryption and decryption.

This list of additional roles is by default empty which makes these
changes a no-op for existing users of this module.

These changes were found to be useful when developing the code in `github-org-artichoke` for the experimentation in https://github.com/artichoke/project-infrastructure/pull/232. These changes cannot be applied until https://github.com/artichoke/project-infrastructure/pull/234 is merged as well.