### PR TITLE
Cease using `s3:kms` with CMK as default encryption for S3 buckets

### DIFF
--- a/modules/access-logs-s3-bucket/main.tf
+++ b/modules/access-logs-s3-bucket/main.tf
@@ -66,20 +66,12 @@ resource "aws_s3_bucket_public_access_block" "this" {
   }
 }
 
-module "kms_key" {
-  source = "../kms-key"
-
-  description       = "Key for encrypting ${var.bucket} S3 bucket"
-  alias_name_prefix = "s3-sse-${var.bucket}-"
-}
-
 resource "aws_s3_bucket_server_side_encryption_configuration" "this" {
   bucket = aws_s3_bucket.this.id
 
   rule {
     apply_server_side_encryption_by_default {
-      kms_master_key_id = module.kms_key.key_arn
-      sse_algorithm     = "aws:kms"
+      sse_algorithm = "AES256"
     }
   }
 

--- a/modules/private-archive-s3-bucket/main.tf
+++ b/modules/private-archive-s3-bucket/main.tf
@@ -63,20 +63,12 @@ resource "aws_s3_bucket_public_access_block" "this" {
   }
 }
 
-module "kms_key" {
-  source = "../kms-key"
-
-  description       = "Key for encrypting ${var.bucket} S3 bucket"
-  alias_name_prefix = "s3-sse-${var.bucket}-"
-}
-
 resource "aws_s3_bucket_server_side_encryption_configuration" "this" {
   bucket = aws_s3_bucket.this.id
 
   rule {
     apply_server_side_encryption_by_default {
-      kms_master_key_id = module.kms_key.key_arn
-      sse_algorithm     = "aws:kms"
+      sse_algorithm = "AES256"
     }
   }
 

--- a/modules/private-s3-bucket/main.tf
+++ b/modules/private-s3-bucket/main.tf
@@ -40,20 +40,12 @@ resource "aws_s3_bucket_public_access_block" "this" {
   }
 }
 
-module "kms_key" {
-  source = "../kms-key"
-
-  description       = "Key for encrypting ${var.bucket} S3 bucket"
-  alias_name_prefix = "s3-sse-${var.bucket}-"
-}
-
 resource "aws_s3_bucket_server_side_encryption_configuration" "this" {
   bucket = aws_s3_bucket.this.id
 
   rule {
     apply_server_side_encryption_by_default {
-      kms_master_key_id = module.kms_key.key_arn
-      sse_algorithm     = "aws:kms"
+      sse_algorithm = "AES256"
     }
   }
 


### PR DESCRIPTION
Remove KMS keys from the following modules:

- `access-logs-s3-bucket`
- `private-s3-bucket`
- `private-archive-s3-bucket`

The Artichoke organization already has an SCP to prevent unencrypted
uploads from making it into S3 buckets. SSE with the S3-managed key is
sufficient and easier to use (simply pass `--sse AES256` on the `asw s3`
CLI) and does not require passing around KMS key IDs.

This removes a bunch of complexity and does not sacrifice security in
any meaningful way for this project.

This change switches the default bucket encryption configuration to
AES256 with the SSE-S3 key management strategy. The previously
provisioned KMS keys are destroyed.

This has the consequence of rendering some bucket objects unreachable.
Some of these are access logs which will age out. Others are terraform
state versions, which are lost.

These changes were found to be useful when developing the code in `github-org-artichoke` for the experimentation in https://github.com/artichoke/project-infrastructure/pull/232. These changes cannot be applied until https://github.com/artichoke/project-infrastructure/pull/233 is merged as well.