### PR TITLE
Add tfsec ignores

### DIFF
--- a/.github/workflows/tfsec.yaml
+++ b/.github/workflows/tfsec.yaml
@@ -45,7 +45,7 @@ jobs:
           terraform -chdir=remote-state init
 
       - name: "tfsec aws"
-        uses: docker://tfsec/tfsec:latest
+        uses: docker://aquasec/tfsec:latest
         id: tfsec_aws
         continue-on-error: true
         with:
@@ -53,7 +53,7 @@ jobs:
           args: aws
 
       - name: "tfsec github-org-artichoke"
-        uses: docker://tfsec/tfsec:latest
+        uses: docker://aquasec/tfsec:latest
         id: tfsec_github_artichoke
         continue-on-error: true
         with:
@@ -61,7 +61,7 @@ jobs:
           args: github-org-artichoke
 
       - name: "tfsec github-org-artichokeruby"
-        uses: docker://tfsec/tfsec:latest
+        uses: docker://aquasec/tfsec:latest
         id: tfsec_github_artichokeruby
         continue-on-error: true
         with:
@@ -69,7 +69,7 @@ jobs:
           args: github-org-artichokeruby
 
       - name: "tfsec github-org-artichoke-ruby"
-        uses: docker://tfsec/tfsec:latest
+        uses: docker://aquasec/tfsec:latest
         id: tfsec_github_artichoke_ruby
         continue-on-error: true
         with:
@@ -77,7 +77,7 @@ jobs:
           args: github-org-artichoke-ruby
 
       - name: "tfsec remote-state"
-        uses: docker://tfsec/tfsec:latest
+        uses: docker://aquasec/tfsec:latest
         id: tfsec_remote_state
         continue-on-error: true
         with:

--- a/modules/github-actions-s3-bucket-read-only-access/main.tf
+++ b/modules/github-actions-s3-bucket-read-only-access/main.tf
@@ -49,7 +49,7 @@ data "aws_iam_policy_document" "bucket_read_only" {
     actions = [
       "s3:GetObject",
     ]
-    resources = ["${data.aws_s3_bucket.bucket.arn}/*"]
+    resources = ["${data.aws_s3_bucket.bucket.arn}/*"] # tfsec:ignore:aws-iam-no-policy-wildcards
   }
 }
 

--- a/modules/github-actions-s3-repo-backup-access/main.tf
+++ b/modules/github-actions-s3-repo-backup-access/main.tf
@@ -39,7 +39,7 @@ data "aws_iam_policy_document" "backup" {
       "s3:PutObject"
     ]
 
-    resources = ["${data.aws_s3_bucket.bucket.arn}/${var.github_repository}/*"]
+    resources = ["${data.aws_s3_bucket.bucket.arn}/${var.github_repository}/*"] # tfsec:ignore:aws-iam-no-policy-wildcards
   }
 }
 

--- a/modules/private-archive-s3-bucket/main.tf
+++ b/modules/private-archive-s3-bucket/main.tf
@@ -63,6 +63,7 @@ resource "aws_s3_bucket_public_access_block" "this" {
   }
 }
 
+# tfsec:ignore:aws-s3-encryption-customer-key
 resource "aws_s3_bucket_server_side_encryption_configuration" "this" {
   bucket = aws_s3_bucket.this.id
 

--- a/modules/private-s3-bucket/main.tf
+++ b/modules/private-s3-bucket/main.tf
@@ -40,6 +40,7 @@ resource "aws_s3_bucket_public_access_block" "this" {
   }
 }
 
+# tfsec:ignore:aws-s3-encryption-customer-key
 resource "aws_s3_bucket_server_side_encryption_configuration" "this" {
   bucket = aws_s3_bucket.this.id
 


### PR DESCRIPTION
tfsec v1.5.0 added support for the S3 bucket refactor in terraform AWS provider version 4.

Run through the config with this version and add ignore pragmas to get things back to green.