### PR TITLE
Bump Ruby toolchain to 3.1.1 across organization

### DIFF
--- a/github-org-artichoke/repository_file_ruby_version.tf
+++ b/github-org-artichoke/repository_file_ruby_version.tf
@@ -1,5 +1,5 @@
 locals {
-  force_bump_ruby_version = true
+  force_bump_ruby_version = false
 
   // https://github.com/ruby/ruby/tree/v3_1_0
   ruby_version = "3.1.1"

--- a/github-org-artichoke/repository_file_ruby_version.tf
+++ b/github-org-artichoke/repository_file_ruby_version.tf
@@ -1,8 +1,8 @@
 locals {
-  force_bump_ruby_version = false
+  force_bump_ruby_version = true
 
   // https://github.com/ruby/ruby/tree/v3_1_0
-  ruby_version = "3.1.0"
+  ruby_version = "3.1.1"
 
   ruby_version_repos = [
     // Artichoke's `.ruby-version` file is not managed with Terraform because


### PR DESCRIPTION
artichoke/artichoke is already at 3.1.1, bump everywhere else:

- https://github.com/artichoke/artichoke.github.io/pull/106
- https://github.com/artichoke/boba/pull/131
- https://github.com/artichoke/cactusref/pull/98
- https://github.com/artichoke/docker-artichoke-nightly/pull/81
- https://github.com/artichoke/focaccia/pull/125
- https://github.com/artichoke/intaglio/pull/133
- https://github.com/artichoke/nightly/pull/56
- https://github.com/artichoke/playground/pull/798
- https://github.com/artichoke/project-infrastructure/pull/252
- https://github.com/artichoke/rand_mt/pull/132
- https://github.com/artichoke/raw-parts/pull/31
- https://github.com/artichoke/roe/pull/77
- https://github.com/artichoke/ruby-file-expand-path/pull/26
- https://github.com/artichoke/rubyconf/pull/395
- https://github.com/artichoke/strudel/pull/105