### PR TITLE
Remove actions-rs/toolchain from Audit workflows

### DIFF
--- a/github-org-artichoke/repository_file_github_actions_audit_workflow.tf
+++ b/github-org-artichoke/repository_file_github_actions_audit_workflow.tf
@@ -24,7 +24,7 @@ locals {
     "rubyconf",            // https://github.com/artichoke/rubyconf
   ]
 
-  force_bump_audit_ruby_rust = false
+  force_bump_audit_ruby_rust = true
   audit_ruby_rust_repos = [
     "artichoke",             // https://github.com/artichoke/artichoke
     "boba",                  // https://github.com/artichoke/boba
@@ -38,7 +38,7 @@ locals {
     "strudel",               // https://github.com/artichoke/strudel
   ]
 
-  force_bump_audit_node_ruby_rust = false
+  force_bump_audit_node_ruby_rust = true
   audit_node_ruby_rust_repos = [
     "playground", // https://github.com/artichoke/playground
   ]

--- a/github-org-artichoke/repository_file_github_actions_audit_workflow.tf
+++ b/github-org-artichoke/repository_file_github_actions_audit_workflow.tf
@@ -24,7 +24,7 @@ locals {
     "rubyconf",            // https://github.com/artichoke/rubyconf
   ]
 
-  force_bump_audit_ruby_rust = true
+  force_bump_audit_ruby_rust = false
   audit_ruby_rust_repos = [
     "artichoke",             // https://github.com/artichoke/artichoke
     "boba",                  // https://github.com/artichoke/boba
@@ -38,7 +38,7 @@ locals {
     "strudel",               // https://github.com/artichoke/strudel
   ]
 
-  force_bump_audit_node_ruby_rust = true
+  force_bump_audit_node_ruby_rust = false
   audit_node_ruby_rust_repos = [
     "playground", // https://github.com/artichoke/playground
   ]

--- a/github-org-artichoke/repository_file_github_actions_audit_workflow.tf
+++ b/github-org-artichoke/repository_file_github_actions_audit_workflow.tf
@@ -43,7 +43,7 @@ locals {
     "playground", // https://github.com/artichoke/playground
   ]
 
-  // https://github.com/EmbarkStudios/cargo-deny/releases/tag/0.11.2
+  // https://github.com/EmbarkStudios/cargo-deny/releases/tag/0.11.3
   cargo_deny = {
     version  = "0.11.3"
     base_url = "https://github.com/EmbarkStudios/cargo-deny/releases/download"

--- a/github-org-artichoke/templates/audit-workflow-node-ruby-rust.yaml
+++ b/github-org-artichoke/templates/audit-workflow-node-ruby-rust.yaml
@@ -50,16 +50,27 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
+        run: |
+          echo "::group::rustup toolchain install"
+          rustup toolchain install stable --profile minimal
+          echo "::endgroup::"
+          echo "::group::set default toolchain"
+          rustup default stable
+          echo "::endgroup::"
+          echo "::group::rustup version"
+          rustup -Vv
+          echo "::endgroup::"
+          echo "::group::rustc version"
+          rustc -Vv
+          echo "::endgroup::"
+          echo "::group::cargo version"
+          cargo version --verbose
+          echo "::endgroup::"
 
       - name: Generate Cargo.lock
         run: |
           if [[ ! -f "Cargo.lock" ]]; then
-            cargo generate-lockfile --verbose
+            cargo +stable generate-lockfile --verbose
           fi
 
       - name: Setup cargo-deny

--- a/github-org-artichoke/templates/audit-workflow-ruby-rust.yaml
+++ b/github-org-artichoke/templates/audit-workflow-ruby-rust.yaml
@@ -36,16 +36,27 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
+        run: |
+          echo "::group::rustup toolchain install"
+          rustup toolchain install stable --profile minimal
+          echo "::endgroup::"
+          echo "::group::set default toolchain"
+          rustup default stable
+          echo "::endgroup::"
+          echo "::group::rustup version"
+          rustup -Vv
+          echo "::endgroup::"
+          echo "::group::rustc version"
+          rustc -Vv
+          echo "::endgroup::"
+          echo "::group::cargo version"
+          cargo version --verbose
+          echo "::endgroup::"
 
       - name: Generate Cargo.lock
         run: |
           if [[ ! -f "Cargo.lock" ]]; then
-            cargo generate-lockfile --verbose
+            cargo +stable generate-lockfile --verbose
           fi
 
       - name: Setup cargo-deny


### PR DESCRIPTION
These actions may be unmaintained. Replace with raw calls to `rustup`.

See:

- https://github.com/artichoke/artichoke/pull/1813

These changes are applied and were merged in the following PRs:

- https://github.com/artichoke/strudel/pull/110
- https://github.com/artichoke/ruby-file-expand-path/pull/32
- https://github.com/artichoke/roe/pull/83
- https://github.com/artichoke/raw-parts/pull/37
- https://github.com/artichoke/rand_mt/pull/138
- https://github.com/artichoke/intaglio/pull/152
- https://github.com/artichoke/focaccia/pull/132
- https://github.com/artichoke/cactusref/pull/107
- https://github.com/artichoke/boba/pull/144
- https://github.com/artichoke/playground/pull/823

A PR was not applied to artichoke/artichoke since the changes in this branch and template were already merged when they were piloted in https://github.com/artichoke/artichoke/pull/1813.

This PR had a misfire which resulted in a bunch of bad PRs being created because it was applied before https://github.com/artichoke/project-infrastructure/pull/263 was merged and would have rolled back all of the `actions/checkout@v3` version bumps. These PRs were closed and superseded by those above:

- https://github.com/artichoke/strudel/pull/109
- https://github.com/artichoke/ruby-file-expand-path/pull/31
- https://github.com/artichoke/roe/pull/82
- https://github.com/artichoke/raw-parts/pull/36
- https://github.com/artichoke/rand_mt/pull/137
- https://github.com/artichoke/intaglio/pull/151
- https://github.com/artichoke/focaccia/pull/131
- https://github.com/artichoke/cactusref/pull/106
- https://github.com/artichoke/boba/pull/143