### PR TITLE
Manage rustdoc workflow with terraform

### DIFF
--- a/github-org-artichoke/outputs.tf
+++ b/github-org-artichoke/outputs.tf
@@ -23,6 +23,11 @@ output "audit_workflow_node_ruby_rust_branches" {
   value       = join("\n", concat(length(module.audit_workflow_node_ruby_rust) == 0 ? [] : ["## Branches", ""], formatlist("- %s", [for repo, audit_workflow in module.audit_workflow_node_ruby_rust : audit_workflow.branch_href])))
 }
 
+output "rustdoc_workflow_branches" {
+  description = "Links to GitHub with changes to the `rustdoc` workflow"
+  value       = join("\n", concat(length(module.rustdoc_workflow) == 0 ? [] : ["## Branches", ""], formatlist("- %s", [for repo, rustdoc_workflow in module.rustdoc_workflow : rustdoc_workflow.branch_href])))
+}
+
 output "s3_backup_workflow_branches" {
   description = "Links to GitHub with changes to the `s3-backup` workflow"
   value       = join("\n", concat(length(module.s3_backup_workflow) == 0 ? [] : ["## Branches", ""], formatlist("- %s", [for repo, backup_workflow in module.s3_backup_workflow : backup_workflow.branch_href])))

--- a/github-org-artichoke/repository_file_github_actions_rustdoc_workflow.tf
+++ b/github-org-artichoke/repository_file_github_actions_rustdoc_workflow.tf
@@ -1,0 +1,31 @@
+locals {
+  // Set `force_bump_...` to true to create branches for PRs that update the
+  // rustdoc Documentation workflow organization-wide.
+
+  force_bump_rustdoc = false
+  rustdoc_repos = [
+    // artichoke has custom bits that are manually managed.
+    // playground does not deploy rustdoc to GitHub Pages.
+
+    "boba",                  // https://github.com/artichoke/boba
+    "cactusref",             // https://github.com/artichoke/cactusref
+    "focaccia",              // https://github.com/artichoke/focaccia
+    "intaglio",              // https://github.com/artichoke/intaglio
+    "rand_mt",               // https://github.com/artichoke/rand_mt
+    "raw-parts",             // https://github.com/artichoke/raw-parts
+    "roe",                   // https://github.com/artichoke/roe
+    "ruby-file-expand-path", // https://github.com/artichoke/ruby-file-expand-path
+    "strudel",               // https://github.com/artichoke/strudel
+  ]
+}
+
+module "rustdoc_workflow" {
+  source   = "../modules/update-github-repository-file"
+  for_each = local.force_bump_rustdoc ? toset(local.rustdoc_repos) : toset([])
+
+  organization  = "artichoke"
+  repository    = each.value
+  base_branch   = "trunk"
+  file_path     = ".github/workflows/rustdoc.yaml"
+  file_contents = file("${path.module}/templates/rustdoc-workflow.yaml")
+}

--- a/github-org-artichoke/repository_file_github_actions_rustdoc_workflow.tf
+++ b/github-org-artichoke/repository_file_github_actions_rustdoc_workflow.tf
@@ -2,7 +2,7 @@ locals {
   // Set `force_bump_...` to true to create branches for PRs that update the
   // rustdoc Documentation workflow organization-wide.
 
-  force_bump_rustdoc = false
+  force_bump_rustdoc = true
   rustdoc_repos = [
     // artichoke has custom bits that are manually managed.
     // playground does not deploy rustdoc to GitHub Pages.

--- a/github-org-artichoke/repository_file_github_actions_rustdoc_workflow.tf
+++ b/github-org-artichoke/repository_file_github_actions_rustdoc_workflow.tf
@@ -2,7 +2,7 @@ locals {
   // Set `force_bump_...` to true to create branches for PRs that update the
   // rustdoc Documentation workflow organization-wide.
 
-  force_bump_rustdoc = true
+  force_bump_rustdoc = false
   rustdoc_repos = [
     // artichoke has custom bits that are manually managed.
     // playground does not deploy rustdoc to GitHub Pages.

--- a/github-org-artichoke/templates/rustdoc-workflow.yaml
+++ b/github-org-artichoke/templates/rustdoc-workflow.yaml
@@ -42,14 +42,6 @@ jobs:
           cargo version --verbose
           echo "::endgroup::"
 
-      - name: Generate Cargo.lock
-        run: |
-          if [[ ! -f "Cargo.lock" ]]; then
-            cargo generate-lockfile --verbose
-          fi
-
-      - uses: Swatinem/rust-cache@v1
-
       - name: Build Documentation
         run: cargo doc --workspace
 

--- a/github-org-artichoke/templates/rustdoc-workflow.yaml
+++ b/github-org-artichoke/templates/rustdoc-workflow.yaml
@@ -1,0 +1,71 @@
+---
+name: Documentation
+"on":
+  push:
+    branches:
+      - trunk
+  pull_request:
+    branches:
+      - trunk
+  schedule:
+    - cron: "0 0 * * TUE"
+concurrency:
+  group: docs-${{ github.head_ref }}
+jobs:
+  rustdoc:
+    name: Build Rust API docs
+    runs-on: ubuntu-latest
+    env:
+      RUSTDOCFLAGS: -D warnings -D rustdoc::broken_intra_doc_links --cfg docsrs
+      RUST_BACKTRACE: 1
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install nightly Rust toolchain
+        run: |
+          echo "::group::rustup toolchain install"
+          rustup toolchain install nightly --profile minimal
+          echo "::endgroup::"
+          echo "::group::set default toolchain"
+          rm -rf rust-toolchain
+          rustup default nightly
+          echo "::endgroup::"
+          echo "::group::rustup version"
+          rustup -Vv
+          echo "::endgroup::"
+          echo "::group::rustc version"
+          rustc -Vv
+          echo "::endgroup::"
+          echo "::group::cargo version"
+          cargo version --verbose
+          echo "::endgroup::"
+
+      - name: Generate Cargo.lock
+        run: |
+          if [[ ! -f "Cargo.lock" ]]; then
+            cargo generate-lockfile --verbose
+          fi
+
+      - uses: Swatinem/rust-cache@v1
+
+      - name: Build Documentation
+        run: cargo doc --workspace
+
+      # https://github.com/artichoke/artichoke/issues/1826
+      - name: Purge sources from out dir
+        run: find . -path './target/doc/*/target/debug/build/*' | xargs rm -rf
+
+      - name: Deploy Docs
+        uses: peaceiris/actions-gh-pages@v3
+        if: github.ref == 'refs/heads/trunk'
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./target/doc
+          publish_branch: gh-pages
+          user_name: artichoke-ci
+          user_email: ci@artichokeruby.org
+          # only have the most recent docs in the `gh-pages` branch
+          # https://github.com/artichoke/artichoke/issues/1826
+          force_orphan: true


### PR DESCRIPTION
See this issue for motivation:

- https://github.com/artichoke/artichoke/issues/1826

These changes are applied and have been deployed:

- https://github.com/artichoke/strudel/pull/111
- https://github.com/artichoke/ruby-file-expand-path/pull/33
- https://github.com/artichoke/roe/pull/84
- https://github.com/artichoke/raw-parts/pull/38
- https://github.com/artichoke/rand_mt/pull/139
- https://github.com/artichoke/intaglio/pull/153
- https://github.com/artichoke/focaccia/pull/133
- https://github.com/artichoke/cactusref/pull/108
- https://github.com/artichoke/boba/pull/145