### PR TITLE
Upgrade Ruby toolchain in organization to 3.1.2

### DIFF
--- a/github-org-artichoke/repository_file_ruby_version.tf
+++ b/github-org-artichoke/repository_file_ruby_version.tf
@@ -1,8 +1,8 @@
 locals {
   force_bump_ruby_version = false
 
-  // https://github.com/ruby/ruby/tree/v3_1_0
-  ruby_version = "3.1.1"
+  // https://github.com/ruby/ruby/tree/v3_1_2
+  ruby_version = "3.1.2"
 
   ruby_version_repos = [
     // Artichoke's `.ruby-version` file is not managed with Terraform because

--- a/github-org-artichoke/repository_file_ruby_version.tf
+++ b/github-org-artichoke/repository_file_ruby_version.tf
@@ -1,5 +1,5 @@
 locals {
-  force_bump_ruby_version = true
+  force_bump_ruby_version = false
 
   // https://github.com/ruby/ruby/tree/v3_1_2
   ruby_version = "3.1.2"

--- a/github-org-artichoke/repository_file_ruby_version.tf
+++ b/github-org-artichoke/repository_file_ruby_version.tf
@@ -15,6 +15,7 @@ locals {
     "nightly",                  // https://github.com/artichoke/nightly
     "playground",               // https://github.com/artichoke/playground
     "project-infrastructure",   // https://github.com/artichoke/project-infrastructure
+    "qed",                      // https://github.com/artichoke/qed
     "rand_mt",                  // https://github.com/artichoke/rand_mt
     "raw-parts",                // https://github.com/artichoke/raw-parts
     "roe",                      // https://github.com/artichoke/roe

--- a/github-org-artichoke/repository_file_ruby_version.tf
+++ b/github-org-artichoke/repository_file_ruby_version.tf
@@ -5,10 +5,7 @@ locals {
   ruby_version = "3.1.2"
 
   ruby_version_repos = [
-    // Artichoke's `.ruby-version` file is not managed with Terraform because
-    // Ruby version upgrade require extra (and manual) care.
-    //
-    // "artichoke",             // https://github.com/artichoke/artichoke
+    "artichoke",                // https://github.com/artichoke/artichoke
     "artichoke.github.io",      // https://github.com/artichoke/artichoke.github.io
     "boba",                     // https://github.com/artichoke/boba
     "cactusref",                // https://github.com/artichoke/cactusref

--- a/github-org-artichoke/repository_file_ruby_version.tf
+++ b/github-org-artichoke/repository_file_ruby_version.tf
@@ -1,5 +1,5 @@
 locals {
-  force_bump_ruby_version = false
+  force_bump_ruby_version = true
 
   // https://github.com/ruby/ruby/tree/v3_1_2
   ruby_version = "3.1.2"


### PR DESCRIPTION
See:

- https://www.ruby-lang.org/en/news/2022/04/12/ruby-3-1-2-released/
- https://www.ruby-lang.org/en/news/2022/04/12/double-free-in-regexp-compilation-cve-2022-28738/
- https://www.ruby-lang.org/en/news/2022/04/12/buffer-overrun-in-string-to-float-cve-2022-28739/

Pull in fixes for these CVEs:

- CVE-2022-28738
- CVE-2022-28739

## PRs

The following PRs were created from this branch:

- https://github.com/artichoke/artichoke/pull/1837
- https://github.com/artichoke/artichoke.github.io/pull/111
- https://github.com/artichoke/boba/pull/147
- https://github.com/artichoke/cactusref/pull/109
- https://github.com/artichoke/docker-artichoke-nightly/pull/97
- https://github.com/artichoke/focaccia/pull/134
- https://github.com/artichoke/intaglio/pull/155
- https://github.com/artichoke/nightly/pull/60
- https://github.com/artichoke/playground/pull/825
- https://github.com/artichoke/project-infrastructure/pull/271
- https://github.com/artichoke/qed/pull/7
- https://github.com/artichoke/rand_mt/pull/140
- https://github.com/artichoke/raw-parts/pull/39
- https://github.com/artichoke/roe/pull/85
- https://github.com/artichoke/ruby-file-expand-path/pull/34
- https://github.com/artichoke/rubyconf/pull/405
- https://github.com/artichoke/strudel/pull/112

These changes are already applied.