### PR TITLE
Manage artichoke/qed with terraform

### DIFF
--- a/github-org-artichoke/repos_active.tf
+++ b/github-org-artichoke/repos_active.tf
@@ -233,6 +233,23 @@ module "github_project_infrastructure" {
   ]
 }
 
+module "github_qed" {
+  source = "../modules/github-repository"
+
+  name         = "qed"
+  description  = "∎ Compile-time assertion macros"
+  homepage_url = "https://crates.io/crates/qed"
+
+  topics = [
+    "assert",
+    "compile-time",
+    "const-assert",
+    "no-std",
+    "rust",
+    "rust-crate",
+  ]
+}
+
 module "github_rand_mt" {
   source = "../modules/github-repository"
 

--- a/github-org-artichoke/repository_file_github_actions_audit_workflow.tf
+++ b/github-org-artichoke/repository_file_github_actions_audit_workflow.tf
@@ -31,6 +31,7 @@ locals {
     "cactusref",             // https://github.com/artichoke/cactusref
     "focaccia",              // https://github.com/artichoke/focaccia
     "intaglio",              // https://github.com/artichoke/intaglio
+    "qed",                   // https://github.com/artichoke/qed
     "rand_mt",               // https://github.com/artichoke/rand_mt
     "raw-parts",             // https://github.com/artichoke/raw-parts
     "roe",                   // https://github.com/artichoke/roe

--- a/github-org-artichoke/repository_file_github_actions_rustdoc_workflow.tf
+++ b/github-org-artichoke/repository_file_github_actions_rustdoc_workflow.tf
@@ -11,6 +11,7 @@ locals {
     "cactusref",             // https://github.com/artichoke/cactusref
     "focaccia",              // https://github.com/artichoke/focaccia
     "intaglio",              // https://github.com/artichoke/intaglio
+    "qed",                   // https://github.com/artichoke/qed
     "rand_mt",               // https://github.com/artichoke/rand_mt
     "raw-parts",             // https://github.com/artichoke/raw-parts
     "roe",                   // https://github.com/artichoke/roe


### PR DESCRIPTION
Manage qed repository, rustdoc github actions workflow, and audit github actions workflow.

ruby version becomes managed in https://github.com/artichoke/project-infrastructure/pull/272.

## Apply

```
Terraform will perform the following actions:

  # module.github_qed.github_repository.this will be updated in-place
  ~ resource "github_repository" "this" {
      ~ has_wiki               = true -> false
        id                     = "qed"
        name                   = "qed"
      ~ topics                 = [
          + "artichoke",
          + "assert",
          + "compile-time",
          + "const-assert",
          + "no-std",
          + "rust",
          + "rust-crate",
        ]
        # (27 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

module.github_qed.github_repository.this: Modifying... [id=qed]
module.github_qed.github_repository.this: Modifications complete after 6s [id=qed]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.

Outputs:

audit_workflow_node_branches = ""
audit_workflow_node_ruby_branches = ""
audit_workflow_node_ruby_rust_branches = ""
audit_workflow_ruby_branches = ""
audit_workflow_ruby_rust_branches = ""
ruby_version_branches = ""
rustdoc_workflow_branches = ""
s3_backup_workflow_branches = ""
```