### PR TITLE
Grant @b-n write access to code repositories

### DIFF
--- a/github-org-artichoke/main.tf
+++ b/github-org-artichoke/main.tf
@@ -66,6 +66,7 @@ module "org_members" {
 
   members = toset([
     "artichoke-ci",
+    "b-n",
   ])
 }
 

--- a/github-org-artichoke/main.tf
+++ b/github-org-artichoke/main.tf
@@ -77,9 +77,40 @@ module "team_ci" {
   description = "Builds"
 }
 
+module "team_contributors" {
+  source = "../modules/github-team-contributors"
+
+  name        = "contributors"
+  description = "Code contributors"
+}
+
 module "team_cratesio_publishers" {
   source = "../modules/github-team-crates.io-publishers"
 
   name        = "crates.io publishers"
   description = "Core team with perissions for publishing packages to crates.io"
+}
+
+resource "github_team_repository" "contributor_repos" {
+  for_each = toset([
+    "artichoke",
+    "boba",
+    "cactusref",
+    "clang-format",
+    "focaccia",
+    "intaglio",
+    "jasper",
+    "playground",
+    "qed",
+    "rand_mt",
+    "raw-parts",
+    "roe",
+    "ruby-file-expand-path",
+    "strftime-ruby",
+    "strudel",
+  ])
+
+  team_id    = module.team_contributors.team_id
+  repository = each.value
+  permission = "push"
 }

--- a/modules/github-team-ci/outputs.tf
+++ b/modules/github-team-ci/outputs.tf
@@ -1,9 +1,9 @@
-output "id" {
+output "team_id" {
   description = "GitHub ID for the team"
   value       = github_team.this.id
 }
 
-output "slug" {
+output "team_slug" {
   description = "@-mentionable slug for the team"
   value       = github_team.this.slug
 }

--- a/modules/github-team-contributors/README.md
+++ b/modules/github-team-contributors/README.md
@@ -1,0 +1,27 @@
+# GitHub Team – `contributors`
+
+This folder contains a Terraform module to provision a "contributors" GitHub
+team with human users who contribute to the [@artichoke] organization.
+
+[@artichoke]: https://github.com/artichoke
+
+## Usage
+
+```terraform
+module "team_contributors" {
+  source = "../modules/github-team-contributors"
+
+  name        = "contributors"
+  description = "Code contributors"
+}
+```
+
+## Parameters
+
+- `name`: The name of the GitHub team to create, defaults to `contributors`.
+- `description`: The description of the team's purpose.
+
+## Outputs
+
+- `team_id`: The GitHub API id for the created team.
+- `team_slug`: The URL-safe @-mentionable slug for the created team.

--- a/modules/github-team-contributors/main.tf
+++ b/modules/github-team-contributors/main.tf
@@ -1,0 +1,21 @@
+resource "github_team" "this" {
+  name        = var.name
+  description = var.description
+
+  # only visible to organization owners and members of this team.
+  privacy = "secret"
+}
+
+resource "github_team_members" "this" {
+  team_id = github_team.this.id
+
+  members {
+    username = "lopopolo"
+    role     = "maintainer"
+  }
+
+  members {
+    username = "b-n"
+    role     = "member"
+  }
+}

--- a/modules/github-team-contributors/outputs.tf
+++ b/modules/github-team-contributors/outputs.tf
@@ -1,0 +1,9 @@
+output "id" {
+  description = "GitHub ID for the team"
+  value       = github_team.this.id
+}
+
+output "slug" {
+  description = "@-mentionable slug for the team"
+  value       = github_team.this.slug
+}

--- a/modules/github-team-contributors/outputs.tf
+++ b/modules/github-team-contributors/outputs.tf
@@ -1,9 +1,9 @@
-output "id" {
+output "team_id" {
   description = "GitHub ID for the team"
   value       = github_team.this.id
 }
 
-output "slug" {
+output "team_slug" {
   description = "@-mentionable slug for the team"
   value       = github_team.this.slug
 }

--- a/modules/github-team-contributors/variables.tf
+++ b/modules/github-team-contributors/variables.tf
@@ -1,0 +1,10 @@
+variable "name" {
+  description = "Name of the team, defaults to `ci`"
+  default     = "ci"
+  type        = string
+}
+
+variable "description" {
+  description = "Description of the team"
+  type        = string
+}

--- a/modules/github-team-contributors/versions.tf
+++ b/modules/github-team-contributors/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    github = {
+      source  = "integrations/github"
+      version = "~> 4.20"
+    }
+  }
+
+  required_version = "~> 1.0"
+}

--- a/modules/github-team-crates.io-publishers/outputs.tf
+++ b/modules/github-team-crates.io-publishers/outputs.tf
@@ -1,9 +1,9 @@
-output "id" {
+output "team_id" {
   description = "GitHub ID for the team"
   value       = github_team.this.id
 }
 
-output "slug" {
+output "team_slug" {
   description = "@-mentionable slug for the team"
   value       = github_team.this.slug
 }


### PR DESCRIPTION
Fixes #296.

@b-n is the first external contributor being added to the Artichoke GitHub organization.

This PR grants access to the following repositories:

- artichoke
- boba
- cactusref
- clang-format
- focaccia
- intaglio
- jasper
- playground
- qed
- rand_mt
- raw-parts
- roe
- ruby-file-expand-path
- strftime-ruby
- strudel

These changes create a new team called @artichoke/contributors to manage this access.

This team does NOT have access to any repos that manage web properties (with the exception of artichoke/playground), repos that generate releases (like nightly and docker-artichoke-nightly), artichoke/logo, or forks.

## terraform plan

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following
symbols:
  + create

Terraform will perform the following actions:

  # github_team_repository.contributor_repos["artichoke"] will be created
  + resource "github_team_repository" "contributor_repos" {
      + etag       = (known after apply)
      + id         = (known after apply)
      + permission = "push"
      + repository = "artichoke"
      + team_id    = (known after apply)
    }

  # github_team_repository.contributor_repos["boba"] will be created
  + resource "github_team_repository" "contributor_repos" {
      + etag       = (known after apply)
      + id         = (known after apply)
      + permission = "push"
      + repository = "boba"
      + team_id    = (known after apply)
    }

  # github_team_repository.contributor_repos["cactusref"] will be created
  + resource "github_team_repository" "contributor_repos" {
      + etag       = (known after apply)
      + id         = (known after apply)
      + permission = "push"
      + repository = "cactusref"
      + team_id    = (known after apply)
    }

  # github_team_repository.contributor_repos["clang-format"] will be created
  + resource "github_team_repository" "contributor_repos" {
      + etag       = (known after apply)
      + id         = (known after apply)
      + permission = "push"
      + repository = "clang-format"
      + team_id    = (known after apply)
    }

  # github_team_repository.contributor_repos["focaccia"] will be created
  + resource "github_team_repository" "contributor_repos" {
      + etag       = (known after apply)
      + id         = (known after apply)
      + permission = "push"
      + repository = "focaccia"
      + team_id    = (known after apply)
    }

  # github_team_repository.contributor_repos["intaglio"] will be created
  + resource "github_team_repository" "contributor_repos" {
      + etag       = (known after apply)
      + id         = (known after apply)
      + permission = "push"
      + repository = "intaglio"
      + team_id    = (known after apply)
    }

  # github_team_repository.contributor_repos["jasper"] will be created
  + resource "github_team_repository" "contributor_repos" {
      + etag       = (known after apply)
      + id         = (known after apply)
      + permission = "push"
      + repository = "jasper"
      + team_id    = (known after apply)
    }

  # github_team_repository.contributor_repos["playground"] will be created
  + resource "github_team_repository" "contributor_repos" {
      + etag       = (known after apply)
      + id         = (known after apply)
      + permission = "push"
      + repository = "playground"
      + team_id    = (known after apply)
    }

  # github_team_repository.contributor_repos["qed"] will be created
  + resource "github_team_repository" "contributor_repos" {
      + etag       = (known after apply)
      + id         = (known after apply)
      + permission = "push"
      + repository = "qed"
      + team_id    = (known after apply)
    }

  # github_team_repository.contributor_repos["rand_mt"] will be created
  + resource "github_team_repository" "contributor_repos" {
      + etag       = (known after apply)
      + id         = (known after apply)
      + permission = "push"
      + repository = "rand_mt"
      + team_id    = (known after apply)
    }

  # github_team_repository.contributor_repos["raw-parts"] will be created
  + resource "github_team_repository" "contributor_repos" {
      + etag       = (known after apply)
      + id         = (known after apply)
      + permission = "push"
      + repository = "raw-parts"
      + team_id    = (known after apply)
    }

  # github_team_repository.contributor_repos["roe"] will be created
  + resource "github_team_repository" "contributor_repos" {
      + etag       = (known after apply)
      + id         = (known after apply)
      + permission = "push"
      + repository = "roe"
      + team_id    = (known after apply)
    }

  # github_team_repository.contributor_repos["ruby-file-expand-path"] will be created
  + resource "github_team_repository" "contributor_repos" {
      + etag       = (known after apply)
      + id         = (known after apply)
      + permission = "push"
      + repository = "ruby-file-expand-path"
      + team_id    = (known after apply)
    }

  # github_team_repository.contributor_repos["strftime-ruby"] will be created
  + resource "github_team_repository" "contributor_repos" {
      + etag       = (known after apply)
      + id         = (known after apply)
      + permission = "push"
      + repository = "strftime-ruby"
      + team_id    = (known after apply)
    }

  # github_team_repository.contributor_repos["strudel"] will be created
  + resource "github_team_repository" "contributor_repos" {
      + etag       = (known after apply)
      + id         = (known after apply)
      + permission = "push"
      + repository = "strudel"
      + team_id    = (known after apply)
    }

  # module.org_members.github_membership.members["b-n"] will be created
  + resource "github_membership" "members" {
      + etag     = (known after apply)
      + id       = (known after apply)
      + role     = "member"
      + username = "b-n"
    }

  # module.team_contributors.github_team.this will be created
  + resource "github_team" "this" {
      + create_default_maintainer = false
      + description               = "Code contributors"
      + etag                      = (known after apply)
      + id                        = (known after apply)
      + members_count             = (known after apply)
      + name                      = "contributors"
      + node_id                   = (known after apply)
      + privacy                   = "secret"
      + slug                      = (known after apply)
    }

  # module.team_contributors.github_team_members.this will be created
  + resource "github_team_members" "this" {
      + etag    = (known after apply)
      + id      = (known after apply)
      + team_id = (known after apply)

      + members {
          + role     = "maintainer"
          + username = "lopopolo"
        }
      + members {
          + role     = "member"
          + username = "b-n"
        }
    }

Plan: 18 to add, 0 to change, 0 to destroy.
```