### PR TITLE
Add build step to `rustdoc` GitHub Actions workflow

### DIFF
--- a/github-org-artichoke/repository_file_github_actions_rustdoc_workflow.tf
+++ b/github-org-artichoke/repository_file_github_actions_rustdoc_workflow.tf
@@ -2,7 +2,7 @@ locals {
   // Set `force_bump_...` to true to create branches for PRs that update the
   // rustdoc Documentation workflow organization-wide.
 
-  force_bump_rustdoc = false
+  force_bump_rustdoc = true
   rustdoc_repos = [
     // artichoke has custom bits that are manually managed.
     // playground does not deploy rustdoc to GitHub Pages.

--- a/github-org-artichoke/repository_file_github_actions_rustdoc_workflow.tf
+++ b/github-org-artichoke/repository_file_github_actions_rustdoc_workflow.tf
@@ -2,7 +2,7 @@ locals {
   // Set `force_bump_...` to true to create branches for PRs that update the
   // rustdoc Documentation workflow organization-wide.
 
-  force_bump_rustdoc = true
+  force_bump_rustdoc = false
   rustdoc_repos = [
     // artichoke has custom bits that are manually managed.
     // playground does not deploy rustdoc to GitHub Pages.

--- a/github-org-artichoke/templates/rustdoc-workflow.yaml
+++ b/github-org-artichoke/templates/rustdoc-workflow.yaml
@@ -42,6 +42,12 @@ jobs:
           cargo version --verbose
           echo "::endgroup::"
 
+      - name: Check docs with no default features
+        run: cargo doc --workspace --no-default-features
+
+      - name: Clean docs
+        run: cargo clean
+
       - name: Build Documentation
         run: cargo doc --workspace
 


### PR DESCRIPTION
In https://github.com/artichoke/intaglio/pull/170 it was discovered that `intaglio` had broken intra-doc links when building the docs without all features. Some changes were made to rustdoc CI to catch these errors.

Replicate them here in the base template and deploy them all out.

PRs:

- https://github.com/artichoke/boba/pull/159
- https://github.com/artichoke/cactusref/pull/121
- https://github.com/artichoke/focaccia/pull/148
- https://github.com/artichoke/intaglio/pull/171
- https://github.com/artichoke/qed/pull/34
- https://github.com/artichoke/rand_mt/pull/156
- https://github.com/artichoke/raw-parts/pull/51
- https://github.com/artichoke/roe/pull/96
- https://github.com/artichoke/ruby-file-expand-path/pull/45
- https://github.com/artichoke/strftime-ruby/pull/10
- https://github.com/artichoke/strudel/pull/122

Bugfix PRs:

- https://github.com/artichoke/intaglio/pull/170
- https://github.com/artichoke/boba/pull/160
- https://github.com/artichoke/cactusref/pull/122
- https://github.com/artichoke/roe/pull/97