### PR TITLE
Add lifecycle transitions to the private S3 bucket module

### DIFF
--- a/modules/private-s3-bucket/main.tf
+++ b/modules/private-s3-bucket/main.tf
@@ -15,6 +15,24 @@ resource "aws_s3_bucket_acl" "this" {
   }
 }
 
+resource "aws_s3_bucket_lifecycle_configuration" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  rule {
+    id     = "archive"
+    status = "Enabled"
+
+    noncurrent_version_transition {
+      noncurrent_days = 30
+      storage_class   = "GLACIER_IR"
+    }
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
 resource "aws_s3_bucket_logging" "this" {
   bucket        = aws_s3_bucket.this.id
   target_bucket = var.access_logs_bucket


### PR DESCRIPTION
- Transition non-current versions to `GLACIER_IR` after 30 days.

The practical impact of this change is that non-current versions of terraform state will move to cheaper storage. These non-current versions are still retained.