### PR TITLE
Remove customer managed KMS key from `terraform_statelock` dynamo table

### DIFF
--- a/remote-state/main.tf
+++ b/remote-state/main.tf
@@ -21,13 +21,7 @@ module "remote_state" {
   access_logs_bucket = module.remote_state_access_logs.name
 }
 
-module "dynamo_statelock_kms" {
-  source = "../modules/kms-key"
-
-  description       = "Key for encrypting remote state DynamoDB table"
-  alias_name_prefix = "dynamodb-remote-state-"
-}
-
+# tfsec:ignore:aws-dynamodb-table-customer-key
 resource "aws_dynamodb_table" "terraform_statelock" {
   name           = "terraform_statelock"
   read_capacity  = 20
@@ -39,8 +33,7 @@ resource "aws_dynamodb_table" "terraform_statelock" {
   }
 
   server_side_encryption {
-    enabled     = true
-    kms_key_arn = module.dynamo_statelock_kms.key_arn
+    enabled = true
   }
 
   attribute {


### PR DESCRIPTION
This costs $1 a month and does not make a meaningful security improvement
over the AWS-managed CMK.