### PR TITLE
Add `aws s3 sync` permissions to codecov role

### DIFF
--- a/aws/main.tf
+++ b/aws/main.tf
@@ -78,7 +78,7 @@ module "code_coverage" {
 }
 
 module "github_actions_code_coverage_assume_role" {
-  source   = "../modules/github-actions-s3-repo-backup-access"
+  source   = "../modules/github-actions-s3-code-coverage-sync-access"
   for_each = toset(local.code_coverage_repositories)
 
   github_oidc_provider_arn = module.github_actions_oidc_provider.arn

--- a/modules/github-actions-s3-code-coverage-sync-access/README.md
+++ b/modules/github-actions-s3-code-coverage-sync-access/README.md
@@ -1,0 +1,58 @@
+# GitHub OIDC S3 Bucket Repository Code Coverage Sync Access
+
+This folder contains a Terraform module to provision an IAM role to allow GitHub
+Actions in a specific repository `aws s3 sync --delete` to an S3 bucket for code
+coverage results using an existing GitHub OpenID Connect provider.
+
+The given repository is given `s3:ListBucket`, `s3:PutObject`, and
+`s3:DeleteObject` permissions to a folder with the same name as the repository
+in the given S3 bucket.
+
+## Usage
+
+```terraform
+module "github_actions_oidc_provider" {
+  source = "../modules/github-actions-oidc-provider"
+}
+
+module "github_actions_strftime_ruby_assume_role" {
+  source = "../modules/github-actions-s3-repo-backup-access"
+
+  github_oidc_provider_arn = module.github_actions_oidc_provider.arn
+  github_organization      = "artichoke"
+  github_repository        = "strftime-ruby"
+
+  s3_bucket_name = "artichoke-forge-code-coverage"
+}
+```
+
+## Parameters
+
+- `github_oidc_provider_arn`: AWS IAM OIDC provider ARN for
+  `token.actions.githubusercontent.com`.
+- `github_organization`: The name of the GitHub organization that the target
+  repository is a part of. For example, in
+  <https://github.com/artichoke/project-infrastructure>, the GitHub organization
+  is `artichoke`.
+- `github_repository`: The name of the repository to grant read access to. For
+  example, in <https://github.com/artichoke/project-infrastructure>, the GitHub
+  repository is `project-infrastructure`.
+- `s3_bucket_name`: The name of the S3 bucket to which the target repository
+  should be granted access. This is only the name of the S3 bucket; not its ARN.
+
+## Outputs
+
+- `role_arn`: The ARN of the role that can be assumed in GitHub Actions to
+  access AWS resources.
+
+This module will output the name of a role that can be used with AWS GitHub
+Actions for authenticating to AWS. For example:
+
+```yaml
+- name: Configure AWS Credentials
+  uses: aws-actions/configure-aws-credentials@master
+  with:
+    aws-region: us-west-2
+    role-to-assume: arn:aws:iam::447522982029:role/github-actions-artichoke-project-infrastructure-role
+    role-session-name: GitHubActionsSession@tfsec-terraform
+```

--- a/modules/github-actions-s3-code-coverage-sync-access/main.tf
+++ b/modules/github-actions-s3-code-coverage-sync-access/main.tf
@@ -1,0 +1,56 @@
+# GitHub OpenID Connect with cloud providers
+#
+# https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-cloud-providers
+
+data "aws_iam_policy_document" "github_allow" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [var.github_oidc_provider_arn]
+    }
+
+    condition {
+      test     = "StringLike"
+      variable = "token.actions.githubusercontent.com:sub"
+      values   = ["repo:${var.github_organization}/${var.github_repository}:*"]
+    }
+  }
+}
+
+resource "aws_iam_role" "github_role" {
+  name_prefix        = "gha-${var.github_repository}-s3-backup-"
+  assume_role_policy = data.aws_iam_policy_document.github_allow.json
+}
+
+data "aws_s3_bucket" "bucket" {
+  bucket = var.s3_bucket_name
+}
+
+data "aws_iam_policy_document" "backup" {
+  statement {
+    sid = "WriteBackup"
+
+    effect = "Allow"
+
+    actions = [
+      "s3:ListBucket",
+      "s3:PutObject",
+      "s3:DeleteObject",
+    ]
+
+    resources = ["${data.aws_s3_bucket.bucket.arn}/${var.github_repository}/*"] # tfsec:ignore:aws-iam-no-policy-wildcards
+  }
+}
+
+resource "aws_iam_policy" "backup" {
+  name_prefix = "${var.github_organization}-${var.github_repository}-repo-s3-backup-"
+  policy      = data.aws_iam_policy_document.backup.json
+}
+
+resource "aws_iam_role_policy_attachment" "backup" {
+  role       = aws_iam_role.github_role.name
+  policy_arn = aws_iam_policy.backup.arn
+}

--- a/modules/github-actions-s3-code-coverage-sync-access/main.tf
+++ b/modules/github-actions-s3-code-coverage-sync-access/main.tf
@@ -31,17 +31,28 @@ data "aws_s3_bucket" "bucket" {
 
 data "aws_iam_policy_document" "backup" {
   statement {
-    sid = "WriteBackup"
+    sid = "SyncArtifacts"
 
     effect = "Allow"
 
     actions = [
-      "s3:ListBucket",
       "s3:PutObject",
       "s3:DeleteObject",
     ]
 
     resources = ["${data.aws_s3_bucket.bucket.arn}/${var.github_repository}/*"] # tfsec:ignore:aws-iam-no-policy-wildcards
+  }
+
+  statement {
+    sid = "ListBucket"
+
+    effect = "Allow"
+
+    actions = [
+      "s3:ListBucket",
+    ]
+
+    resources = [data.aws_s3_bucket.bucket.arn]
   }
 }
 

--- a/modules/github-actions-s3-code-coverage-sync-access/outputs.tf
+++ b/modules/github-actions-s3-code-coverage-sync-access/outputs.tf
@@ -1,0 +1,4 @@
+output "role_arn" {
+  value       = aws_iam_role.github_role.arn
+  description = "This is the ARN of the role that can be assumed in GitHub Actions to access AWS resources"
+}

--- a/modules/github-actions-s3-code-coverage-sync-access/variables.tf
+++ b/modules/github-actions-s3-code-coverage-sync-access/variables.tf
@@ -1,0 +1,19 @@
+variable "github_oidc_provider_arn" {
+  description = "AWS IAM OIDC provider ARN for token.actions.githubusercontent.com"
+  type        = string
+}
+
+variable "github_organization" {
+  description = "The GitHub organization to grant access to"
+  type        = string
+}
+
+variable "github_repository" {
+  description = "The GitHub repository in the organization to grant access to"
+  type        = string
+}
+
+variable "s3_bucket_name" {
+  description = "The S3 bucket to grant access to"
+  type        = string
+}

--- a/modules/s3-bucket-website/main.tf
+++ b/modules/s3-bucket-website/main.tf
@@ -98,6 +98,9 @@ resource "aws_acm_certificate" "cert" {
     validation_domain = "artichokeruby.org"
   }
 
+  options {
+    certificate_transparency_logging_preference = "ENABLED"
+  }
 
   lifecycle {
     create_before_destroy = true


### PR DESCRIPTION
I accidentally deleted the ACM certificate from the remote state and had to regenerate it, which is why there is an unrelated change.

Fixes https://github.com/artichoke/project-infrastructure/issues/334.