### PR TITLE
Fix typo in vertical-align property value

### DIFF
--- a/modules/s3-bucket-website-codecov/code-coverage-index.html
+++ b/modules/s3-bucket-website-codecov/code-coverage-index.html
@@ -16,7 +16,7 @@
     />
     <style nonce="b77e5ce9ed">
       .artichoke-valign-middle {
-        vertical-align: midddle;
+        vertical-align: middle;
       }
     </style>
   </head>


### PR DESCRIPTION
Typo'd an extra `d` in `middle`.