### PR TITLE
Use %p in LLVM_PROFILE_FILE for code coverage

### DIFF
--- a/github-org-artichoke/repository_file_github_actions_rust_code_coverage_workflow.tf
+++ b/github-org-artichoke/repository_file_github_actions_rust_code_coverage_workflow.tf
@@ -2,7 +2,7 @@ locals {
   // Set `force_bump_s3_backup` to true to create branches for PRs that update
   // the S3 backup workflow organization-wide.
 
-  force_bump_rust_code_coverage = true
+  force_bump_rust_code_coverage = false
   rust_code_coverage_repos = [
     "boba",          // https://github.com/artichoke/boba
     "focaccia",      // https://github.com/artichoke/focaccia

--- a/github-org-artichoke/repository_file_github_actions_rust_code_coverage_workflow.tf
+++ b/github-org-artichoke/repository_file_github_actions_rust_code_coverage_workflow.tf
@@ -2,7 +2,7 @@ locals {
   // Set `force_bump_s3_backup` to true to create branches for PRs that update
   // the S3 backup workflow organization-wide.
 
-  force_bump_rust_code_coverage = false
+  force_bump_rust_code_coverage = true
   rust_code_coverage_repos = [
     "boba",          // https://github.com/artichoke/boba
     "focaccia",      // https://github.com/artichoke/focaccia

--- a/github-org-artichoke/templates/rust-code-coverage.yaml
+++ b/github-org-artichoke/templates/rust-code-coverage.yaml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Generate coverage
         env:
-          LLVM_PROFILE_FILE: "${github_repository}-%m.profraw"
+          LLVM_PROFILE_FILE: "${github_repository}-%m-%p.profraw"
           RUSTFLAGS: "-C instrument-coverage"
           # Unstable feature: https://github.com/rust-lang/rust/issues/56925
           RUSTDOCFLAGS: "-C instrument-coverage -Z unstable-options --persist-doctests target/debug/doctests"


### PR DESCRIPTION
Fixes #346.

> LLVM Profile Warning: Unable to merge profile data: source profile file is not compatible.
> LLVM Profile Error: Profile Merging of file focaccia-17245978410983498776_0.profraw failed: Success
> LLVM Profile Error: Failed to write file "focaccia-17245978410983498776_0.profraw": Success

When there are multiple doctests in the same module, code coverage is broken (see https://codecov.artichokeruby.org/focaccia/src/lib.rs.html#214).

The `%p` specifier allow us to create a unique file each time, not overwriting older files.