### PR TITLE
Add `posix-space`, `qed`, `strftime-ruby` to published crates docs

### DIFF
--- a/docs/crates.io.md
+++ b/docs/crates.io.md
@@ -22,19 +22,22 @@ used as dependencies in a Rust project with Cargo.
 
 ## Crates
 
-| Crate              | Description                                                               | Who Are Admins?                                | Has Team Owner? | Crate Reservation? |
-| ------------------ | ------------------------------------------------------------------------- | ---------------------------------------------- | --------------- | ------------------ |
-| [`artichoke`]      | Empty crate, used only to reserve the name                                | [@lopopolo], [@artichoke/crates-io-publishers] | ✅              | ✅                 |
-| [`artichokeruby`]  | Empty crate, used only to reserve the name                                | [@lopopolo], [@artichoke/crates-io-publishers] | ✅              | ✅                 |
-| [`artichoke-ruby`] | Empty crate, used only to reserve the name                                | [@lopopolo], [@artichoke/crates-io-publishers] | ✅              | ✅                 |
-| [`boba`]           | Encoder and decoder for the Bubble Babble binary data encoding            | [@lopopolo], [@artichoke/crates-io-publishers] | ✅              |                    |
-| [`cactusref`]      | Cycle-aware reference counting smart pointer                              | [@lopopolo], [@artichoke/crates-io-publishers] | ✅              |                    |
-| [`focaccia`]       | no_std implementation of Unicode case folding comparisons                 | [@lopopolo], [@artichoke/crates-io-publishers] | ✅              |                    |
-| [`intaglio`]       | UTF-8 string and bytestring interner and symbol table                     | [@lopopolo], [@artichoke/crates-io-publishers] | ✅              |                    |
-| [`invokedynamic`]  | Empty crate, used only to reserve the name                                | [@lopopolo], [@artichoke/crates-io-publishers] | ✅              | ✅                 |
-| [`rand_mt`]        | Reference Mersenne Twister random number generators.                      | [@lopopolo], [@artichoke/crates-io-publishers] | ✅              |                    |
-| [`raw-parts`]      | Ergonomic wrapper around `Vec::from_raw_parts` and `Vec::into_raw_parts`. | [@lopopolo], [@artichoke/crates-io-publishers] | ✅              |                    |
-| [`roe`]            | Unicode case conversion                                                   | [@lopopolo], [@artichoke/crates-io-publishers] | ✅              |                    |
+| Crate              | Description                                                               | Who Are Admins?                                            | Has Team Owner? | Crate Reservation? |
+| ------------------ | ------------------------------------------------------------------------- | ---------------------------------------------------------- | --------------- | ------------------ |
+| [`artichoke`]      | Empty crate, used only to reserve the name                                | [@lopopolo], [@artichoke/crates-io-publishers]             | ✅              | ✅                 |
+| [`artichokeruby`]  | Empty crate, used only to reserve the name                                | [@lopopolo], [@artichoke/crates-io-publishers]             | ✅              | ✅                 |
+| [`artichoke-ruby`] | Empty crate, used only to reserve the name                                | [@lopopolo], [@artichoke/crates-io-publishers]             | ✅              | ✅                 |
+| [`boba`]           | Encoder and decoder for the Bubble Babble binary data encoding            | [@lopopolo], [@artichoke/crates-io-publishers]             | ✅              |                    |
+| [`cactusref`]      | Cycle-aware reference counting smart pointer                              | [@lopopolo], [@artichoke/crates-io-publishers]             | ✅              |                    |
+| [`focaccia`]       | no_std implementation of Unicode case folding comparisons                 | [@lopopolo], [@artichoke/crates-io-publishers]             | ✅              |                    |
+| [`intaglio`]       | UTF-8 string and bytestring interner and symbol table                     | [@lopopolo], [@artichoke/crates-io-publishers]             | ✅              |                    |
+| [`invokedynamic`]  | Empty crate, used only to reserve the name                                | [@lopopolo], [@artichoke/crates-io-publishers]             | ✅              | ✅                 |
+| [`posix-space`]    | Pure Rust implementation of `isspace` for the POSIX locale                | [@lopopolo], [@artichoke/crates-io-publishers]             | ✅              |                    |
+| [`qed`]            | Compile-time assertions                                                   | [@lopopolo], [@artichoke/crates-io-publishers]             | ✅              |                    |
+| [`rand_mt`]        | Reference Mersenne Twister random number generators.                      | [@lopopolo], [@artichoke/crates-io-publishers]             | ✅              |                    |
+| [`raw-parts`]      | Ergonomic wrapper around `Vec::from_raw_parts` and `Vec::into_raw_parts`. | [@lopopolo], [@artichoke/crates-io-publishers]             | ✅              |                    |
+| [`roe`]            | Unicode case conversion                                                   | [@lopopolo], [@artichoke/crates-io-publishers]             | ✅              |                    |
+| [`strftime-ruby`]  | Ruby `Time#strftime` parser and formatter                                 | [@lopopolo], [@x-hgg-x], [@artichoke/crates-io-publishers] | ✅              |                    |
 
 [`artichoke`]: https://crates.io/crates/artichoke
 [`artichokeruby`]: https://crates.io/crates/artichokeruby
@@ -44,6 +47,10 @@ used as dependencies in a Rust project with Cargo.
 [`focaccia`]: https://crates.io/crates/focaccia
 [`intaglio`]: https://crates.io/crates/intaglio
 [`invokedynamic`]: https://crates.io/crates/invokedynamic
+[`posix-space`]: https://crates.io/crates/posix-space
+[`qed`]: https://crates.io/crates/qed
 [`rand_mt`]: https://crates.io/crates/rand_mt
 [`raw-parts`]: https://crates.io/crates/raw-parts
 [`roe`]: https://crates.io/crates/roe
+[`strftime-ruby`]: https://crates.io/crates/strftime-ruby
+[@x-hgg-x]: https://github.com/x-hgg-x


### PR DESCRIPTION
Add note about additional maintainers and crate owners.