### PR TITLE
Update rustdoc workflow to deploy docs with GitHub Actions

### DIFF
--- a/github-org-artichoke/repository_file_github_actions_rustdoc_workflow.tf
+++ b/github-org-artichoke/repository_file_github_actions_rustdoc_workflow.tf
@@ -2,7 +2,7 @@ locals {
   // Set `force_bump_...` to true to create branches for PRs that update the
   // rustdoc Documentation workflow organization-wide.
 
-  force_bump_rustdoc = false
+  force_bump_rustdoc = true
   rustdoc_repos = [
     // artichoke has custom bits that are manually managed.
     // playground does not deploy rustdoc to GitHub Pages.

--- a/github-org-artichoke/repository_file_github_actions_rustdoc_workflow.tf
+++ b/github-org-artichoke/repository_file_github_actions_rustdoc_workflow.tf
@@ -2,7 +2,7 @@ locals {
   // Set `force_bump_...` to true to create branches for PRs that update the
   // rustdoc Documentation workflow organization-wide.
 
-  force_bump_rustdoc = true
+  force_bump_rustdoc = false
   rustdoc_repos = [
     // artichoke has custom bits that are manually managed.
     // playground does not deploy rustdoc to GitHub Pages.

--- a/github-org-artichoke/templates/rustdoc-workflow.yaml
+++ b/github-org-artichoke/templates/rustdoc-workflow.yaml
@@ -76,7 +76,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
-    needs: build
+    needs: rustdoc
     if: github.ref == 'refs/heads/trunk'
     steps:
       - name: Deploy to GitHub Pages

--- a/github-org-artichoke/templates/rustdoc-workflow.yaml
+++ b/github-org-artichoke/templates/rustdoc-workflow.yaml
@@ -1,5 +1,6 @@
 ---
 name: Documentation
+
 "on":
   push:
     branches:
@@ -9,15 +10,28 @@ name: Documentation
       - trunk
   schedule:
     - cron: "0 0 * * TUE"
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment per branch
 concurrency:
-  group: docs-${{ github.head_ref }}
+  group: "pages-${{ github.head_ref }}"
+  cancel-in-progress: true
+
 jobs:
+  # Build job
   rustdoc:
     name: Build Rust API docs
     runs-on: ubuntu-latest
     env:
       RUSTDOCFLAGS: -D warnings -D rustdoc::broken_intra_doc_links --cfg docsrs
       RUST_BACKTRACE: 1
+      # https://rust-lang.github.io/rustup/overrides.html
+      RUSTUP_TOOLCHAIN: nightly
 
     steps:
       - name: Checkout repository
@@ -28,10 +42,6 @@ jobs:
           echo "::group::rustup toolchain install"
           rustup toolchain install nightly --profile minimal
           echo "::endgroup::"
-          echo "::group::set default toolchain"
-          rm -rf rust-toolchain
-          rustup default nightly
-          echo "::endgroup::"
           echo "::group::rustup version"
           rustup -Vv
           echo "::endgroup::"
@@ -40,6 +50,9 @@ jobs:
           echo "::endgroup::"
           echo "::group::cargo version"
           cargo version --verbose
+          echo "::endgroup::"
+          echo "::group::rustdoc version"
+          rustdoc -Vv
           echo "::endgroup::"
 
       - name: Check docs with no default features
@@ -51,19 +64,21 @@ jobs:
       - name: Build Documentation
         run: cargo doc --workspace
 
-      # https://github.com/artichoke/artichoke/issues/1826
-      - name: Purge sources from out dir
-        run: find . -path './target/doc/*/target/debug/build/*' | xargs rm -rf
-
-      - name: Deploy Docs
-        uses: peaceiris/actions-gh-pages@v3
-        if: github.ref == 'refs/heads/trunk'
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./target/doc
-          publish_branch: gh-pages
-          user_name: artichoke-ci
-          user_email: ci@artichokeruby.org
-          # only have the most recent docs in the `gh-pages` branch
-          # https://github.com/artichoke/artichoke/issues/1826
-          force_orphan: true
+          path: ./target/doc
+
+  # Deployment job
+  deploy:
+    name: GitHub Pages deploy
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.ref == 'refs/heads/trunk'
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1


### PR DESCRIPTION
Deploy generated Rust API documentation to GitHub Pages using the new GitHub Actions deployment model instead of the `gh-pages` branch deployment model:

- https://github.blog/2022-08-10-github-pages-now-uses-actions-by-default/
- https://github.blog/changelog/2022-07-27-github-pages-custom-github-actions-workflows-beta/

This approach follows the model in the `hugo` starter workflow:

- https://github.com/actions/starter-workflows/blob/edae9e95bf1c84aff6e1d34afcb7bde9288d0e25/pages/hugo.yml

Most updates in the workflow are to model it after the starter workflow template. There are additional changes to Rust toolchain setup:

- Enforce nightly toolchain with the `RUSTUP_TOOLCHAIN` env variable which has high priority per https://rust-lang.github.io/rustup/overrides.html.
- Remove `rustup default nightly` command.
- No longer remove `rust-toolchain` file since `RUSTUP_TOOLCHAIN` has higher priority.
- Print out rustdoc verbose version with `rustdoc -Vv`.

Because generated docs are no longer stored in git, the workaround to remove docs for large generated Rust sources is no longer required and is removed.

`peaceiris/actions-gh-pages` is no longer used to deploy the docs.