### PR TITLE
Use cargo-deny GitHub Action from upstream maintainer

### DIFF
--- a/github-org-artichoke/repository_file_github_actions_audit_workflow.tf
+++ b/github-org-artichoke/repository_file_github_actions_audit_workflow.tf
@@ -45,12 +45,6 @@ locals {
   audit_node_ruby_rust_repos = [
     "playground", // https://github.com/artichoke/playground
   ]
-
-  // https://github.com/EmbarkStudios/cargo-deny/releases/tag/0.11.3
-  cargo_deny = {
-    version  = "0.11.3"
-    base_url = "https://github.com/EmbarkStudios/cargo-deny/releases/download"
-  }
 }
 
 module "audit_workflow_node" {
@@ -95,7 +89,7 @@ module "audit_workflow_ruby_rust" {
   base_branch  = "trunk"
   file_path    = ".github/workflows/audit.yaml"
 
-  file_contents = templatefile("${path.module}/templates/audit-workflow-ruby-rust.yaml", { cargo_deny = local.cargo_deny })
+  file_contents = file("${path.module}/templates/audit-workflow-ruby-rust.yaml")
 }
 
 module "audit_workflow_node_ruby_rust" {
@@ -107,5 +101,5 @@ module "audit_workflow_node_ruby_rust" {
   base_branch  = "trunk"
   file_path    = ".github/workflows/audit.yaml"
 
-  file_contents = templatefile("${path.module}/templates/audit-workflow-node-ruby-rust.yaml", { cargo_deny = local.cargo_deny })
+  file_contents = file("${path.module}/templates/audit-workflow-node-ruby-rust.yaml")
 }

--- a/github-org-artichoke/repository_file_github_actions_audit_workflow.tf
+++ b/github-org-artichoke/repository_file_github_actions_audit_workflow.tf
@@ -24,7 +24,7 @@ locals {
     "rubyconf",            // https://github.com/artichoke/rubyconf
   ]
 
-  force_bump_audit_ruby_rust = true
+  force_bump_audit_ruby_rust = false
   audit_ruby_rust_repos = [
     "artichoke",             // https://github.com/artichoke/artichoke
     "boba",                  // https://github.com/artichoke/boba
@@ -41,7 +41,7 @@ locals {
     "strudel",               // https://github.com/artichoke/strudel
   ]
 
-  force_bump_audit_node_ruby_rust = true
+  force_bump_audit_node_ruby_rust = false
   audit_node_ruby_rust_repos = [
     "playground", // https://github.com/artichoke/playground
   ]

--- a/github-org-artichoke/repository_file_github_actions_audit_workflow.tf
+++ b/github-org-artichoke/repository_file_github_actions_audit_workflow.tf
@@ -24,7 +24,7 @@ locals {
     "rubyconf",            // https://github.com/artichoke/rubyconf
   ]
 
-  force_bump_audit_ruby_rust = false
+  force_bump_audit_ruby_rust = true
   audit_ruby_rust_repos = [
     "artichoke",             // https://github.com/artichoke/artichoke
     "boba",                  // https://github.com/artichoke/boba
@@ -41,7 +41,7 @@ locals {
     "strudel",               // https://github.com/artichoke/strudel
   ]
 
-  force_bump_audit_node_ruby_rust = false
+  force_bump_audit_node_ruby_rust = true
   audit_node_ruby_rust_repos = [
     "playground", // https://github.com/artichoke/playground
   ]

--- a/github-org-artichoke/templates/audit-workflow-node-ruby-rust.yaml
+++ b/github-org-artichoke/templates/audit-workflow-node-ruby-rust.yaml
@@ -44,6 +44,14 @@ jobs:
   rust:
     name: Audit Rust Dependencies
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        checks:
+          - advisories
+          - bans licenses sources
+
+    # Prevent sudden announcement of a new advisory from failing ci:
+    continue-on-error: ${{ matrix.checks == 'advisories' }}
 
     steps:
       - name: Checkout repository
@@ -73,11 +81,8 @@ jobs:
             cargo +stable generate-lockfile --verbose
           fi
 
-      - name: Setup cargo-deny
-        run: curl -sL "${cargo_deny.base_url}/${cargo_deny.version}/cargo-deny-${cargo_deny.version}-x86_64-unknown-linux-musl.tar.gz" | sudo tar xvz -C /usr/local/bin/ --strip-components=1
-
-      - name: Show cargo-deny version
-        run: cargo-deny --version
-
-      - name: Run cargo-deny
-        run: cargo-deny --locked check --show-stats
+      - uses: EmbarkStudios/cargo-deny-action@v1
+        with:
+          arguments: --locked --all-features
+          command: check ${{ matrix.checks }}
+          command-arguments: --show-stats

--- a/github-org-artichoke/templates/audit-workflow-ruby-rust.yaml
+++ b/github-org-artichoke/templates/audit-workflow-ruby-rust.yaml
@@ -30,6 +30,14 @@ jobs:
   rust:
     name: Audit Rust Dependencies
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        checks:
+          - advisories
+          - bans licenses sources
+
+    # Prevent sudden announcement of a new advisory from failing ci:
+    continue-on-error: ${{ matrix.checks == 'advisories' }}
 
     steps:
       - name: Checkout repository
@@ -59,11 +67,8 @@ jobs:
             cargo +stable generate-lockfile --verbose
           fi
 
-      - name: Setup cargo-deny
-        run: curl -sL "${cargo_deny.base_url}/${cargo_deny.version}/cargo-deny-${cargo_deny.version}-x86_64-unknown-linux-musl.tar.gz" | sudo tar xvz -C /usr/local/bin/ --strip-components=1
-
-      - name: Show cargo-deny version
-        run: cargo-deny --version
-
-      - name: Run cargo-deny
-        run: cargo-deny --locked check --show-stats
+      - uses: EmbarkStudios/cargo-deny-action@v1
+        with:
+          arguments: --locked --all-features
+          command: check ${{ matrix.checks }}
+          command-arguments: --show-stats


### PR DESCRIPTION
Remove the need for us to do cargo-deny version bumps in this repository.

The change resulted in these PRs:

- https://github.com/artichoke/artichoke/pull/2171
- https://github.com/artichoke/boba/pull/175
- https://github.com/artichoke/cactusref/pull/128
- https://github.com/artichoke/focaccia/pull/162
- https://github.com/artichoke/intaglio/pull/189
- https://github.com/artichoke/posix-space/pull/17
- https://github.com/artichoke/qed/pull/40
- https://github.com/artichoke/rand_mt/pull/170
- https://github.com/artichoke/raw-parts/pull/63
- https://github.com/artichoke/roe/pull/107
- https://github.com/artichoke/ruby-file-expand-path/pull/50
- https://github.com/artichoke/strftime-ruby/pull/74
- https://github.com/artichoke/strudel/pull/130