### PR TITLE
Update strftime-ruby repo link metadata to crates.io

### DIFF
--- a/github-org-artichoke/repos_active.tf
+++ b/github-org-artichoke/repos_active.tf
@@ -403,7 +403,7 @@ module "github_strftime_ruby" {
 
   name         = "strftime-ruby"
   description  = "⏳ Ruby `Time#strftime` parser and formatter"
-  homepage_url = "https://artichoke.github.io/strftime-ruby/strftime/"
+  homepage_url = "https://crates.io/crates/strftime-ruby"
 
   topics = [
     "ruby",


### PR DESCRIPTION
Now that this crate is published, point the repository URL to crates.io.