### PR TITLE
Manage artichoke/setup-rust repository with terraform

### DIFF
--- a/github-org-artichoke/repos_active.tf
+++ b/github-org-artichoke/repos_active.tf
@@ -382,6 +382,24 @@ module "github_ruby_file_expand_path" {
   ]
 }
 
+module "github_setup_rust" {
+  source = "../modules/github-repository"
+
+  name         = "setup-rust"
+  description  = "⛓ GitHub Actions for setting up Rust toolchains"
+  homepage_url = "https://github.com/artichoke/setup-rust#readme"
+
+  has_github_pages = false
+
+  topics = [
+    "github-actions",
+    "rust",
+    "rustdoc",
+    "rustup",
+    "toolchain",
+  ]
+}
+
 module "github_spec_state" {
   source = "../modules/github-repository"
 


### PR DESCRIPTION
This change is applied:

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following
symbols:
  ~ update in-place

Terraform will perform the following actions:

  # module.github_setup_rust.github_repository.this will be updated in-place
  ~ resource "github_repository" "this" {
      ~ delete_branch_on_merge      = false -> true
      ~ has_wiki                    = true -> false
      + homepage_url                = "https://github.com/artichoke/setup-rust#readme"
        id                          = "setup-rust"
        name                        = "setup-rust"
      ~ squash_merge_commit_message = "COMMIT_MESSAGES" -> "PR_BODY"
      ~ squash_merge_commit_title   = "COMMIT_OR_PR_TITLE" -> "PR_TITLE"
      ~ topics                      = [
          + "artichoke",
          + "github-actions",
          + "rust",
          + "rustdoc",
          + "rustup",
          + "toolchain",
        ]
        # (26 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```