### PR TITLE
Replace actions-rs/toolchain with artichoke/setup-rust for code coverage workflow

### DIFF
--- a/github-org-artichoke/repository_file_github_actions_rust_code_coverage_workflow.tf
+++ b/github-org-artichoke/repository_file_github_actions_rust_code_coverage_workflow.tf
@@ -2,7 +2,7 @@ locals {
   // Set `force_bump_s3_backup` to true to create branches for PRs that update
   // the S3 backup workflow organization-wide.
 
-  force_bump_rust_code_coverage = true
+  force_bump_rust_code_coverage = false
   rust_code_coverage_repos = [
     "boba",          // https://github.com/artichoke/boba
     "focaccia",      // https://github.com/artichoke/focaccia

--- a/github-org-artichoke/repository_file_github_actions_rust_code_coverage_workflow.tf
+++ b/github-org-artichoke/repository_file_github_actions_rust_code_coverage_workflow.tf
@@ -2,7 +2,7 @@ locals {
   // Set `force_bump_s3_backup` to true to create branches for PRs that update
   // the S3 backup workflow organization-wide.
 
-  force_bump_rust_code_coverage = false
+  force_bump_rust_code_coverage = true
   rust_code_coverage_repos = [
     "boba",          // https://github.com/artichoke/boba
     "focaccia",      // https://github.com/artichoke/focaccia

--- a/github-org-artichoke/templates/rust-code-coverage.yaml
+++ b/github-org-artichoke/templates/rust-code-coverage.yaml
@@ -21,13 +21,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          profile: minimal
-          override: true
-          components: llvm-tools-preview
+      - name: Install nightly Rust toolchain
+        uses: artichoke/setup-rust/code-coverage@v1
 
       - name: Setup grcov
         run: |


### PR DESCRIPTION
See:

- https://github.com/artichoke/setup-rust/pull/18
- https://github.com/artichoke/project-infrastructure/issues/265

PRs:

- https://github.com/artichoke/boba/pull/186
- https://github.com/artichoke/focaccia/pull/175
- https://github.com/artichoke/intaglio/pull/199
- https://github.com/artichoke/posix-space/pull/26
- https://github.com/artichoke/rand_mt/pull/177
- https://github.com/artichoke/raw-parts/pull/68
- https://github.com/artichoke/roe/pull/119
- https://github.com/artichoke/strftime-ruby/pull/83