### PR TITLE
Pass GitHub token to GitHub API when fetching grcov release info

### DIFF
--- a/github-org-artichoke/repository_file_github_actions_rust_code_coverage_workflow.tf
+++ b/github-org-artichoke/repository_file_github_actions_rust_code_coverage_workflow.tf
@@ -2,7 +2,7 @@ locals {
   // Set `force_bump_s3_backup` to true to create branches for PRs that update
   // the S3 backup workflow organization-wide.
 
-  force_bump_rust_code_coverage = true
+  force_bump_rust_code_coverage = false
   rust_code_coverage_repos = [
     "boba",          // https://github.com/artichoke/boba
     "focaccia",      // https://github.com/artichoke/focaccia

--- a/github-org-artichoke/repository_file_github_actions_rust_code_coverage_workflow.tf
+++ b/github-org-artichoke/repository_file_github_actions_rust_code_coverage_workflow.tf
@@ -2,7 +2,7 @@ locals {
   // Set `force_bump_s3_backup` to true to create branches for PRs that update
   // the S3 backup workflow organization-wide.
 
-  force_bump_rust_code_coverage = false
+  force_bump_rust_code_coverage = true
   rust_code_coverage_repos = [
     "boba",          // https://github.com/artichoke/boba
     "focaccia",      // https://github.com/artichoke/focaccia

--- a/github-org-artichoke/templates/rust-code-coverage.yaml
+++ b/github-org-artichoke/templates/rust-code-coverage.yaml
@@ -27,10 +27,16 @@ jobs:
       - name: Setup grcov
         run: |
           release_url="$(curl \
-            -H "Accept: application/vnd.github.v3+json" \
-            https://api.github.com/repos/mozilla/grcov/releases | \
-            jq -r '.[0].assets | map(select(.browser_download_url | test(".*x86_64-unknown-linux-musl.tar.bz2$"))) | .[0].browser_download_url')"
-
+            --url https://api.github.com/repos/mozilla/grcov/releases \
+            --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+            --header 'content-type: application/json' \
+            --silent \
+            --fail \
+            --retry 5 \
+            | jq -r '.[0].assets
+                     | map(select(.browser_download_url | test(".*x86_64-unknown-linux-musl.tar.bz2$")))
+                     | .[0].browser_download_url'
+          )"
           curl -sL "$release_url" | sudo tar xvj -C /usr/local/bin/
 
       - name: Generate coverage

--- a/github-org-artichoke/templates/rust-code-coverage.yaml
+++ b/github-org-artichoke/templates/rust-code-coverage.yaml
@@ -39,6 +39,9 @@ jobs:
           )"
           curl -sL "$release_url" | sudo tar xvj -C /usr/local/bin/
 
+      - name: Show grcov version
+        run: grcov --version
+
       - name: Generate coverage
         env:
           LLVM_PROFILE_FILE: "${github_repository}-%m-%p.profraw"

--- a/github-org-artichoke/templates/rust-code-coverage.yaml
+++ b/github-org-artichoke/templates/rust-code-coverage.yaml
@@ -28,7 +28,7 @@ jobs:
         run: |
           release_url="$(curl \
             --url https://api.github.com/repos/mozilla/grcov/releases \
-            --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+            --header 'authorization: Bearer $${{ secrets.GITHUB_TOKEN }}' \
             --header 'content-type: application/json' \
             --silent \
             --fail \


### PR DESCRIPTION
Address a build flake that looks like this:

```
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100   280  100   280    0     0   2944      0 --:--:-- --:--:-- --:--:--  2916
jq: error (at <stdin>:1): Cannot index object with number
Error: Process completed with exit code 5.
```

See for example: https://github.com/artichoke/roe/actions/runs/3815322171/jobs/6490232071

To attempt a fix:

- Set the content type to the more modern application/json.
- Pass `secrets.GITHUB_TOKEN` as a bearer token in the `Authorization` header.
- Use `--silent` and `--fail` to prevent curl from echoing outputs in the subshell pipeline.
- Add 3 retries to the curl call.

This commit also breaks up the `jq` expression over multiple lines for readability and echos the installed `grcov` version.

## Deployed PRs

- https://github.com/artichoke/boba/pull/187
- https://github.com/artichoke/focaccia/pull/178
- https://github.com/artichoke/intaglio/pull/200
- https://github.com/artichoke/posix-space/pull/29
- https://github.com/artichoke/rand_mt/pull/178
- https://github.com/artichoke/raw-parts/pull/69
- https://github.com/artichoke/roe/pull/122
- https://github.com/artichoke/strftime-ruby/pull/84