### PR TITLE
Use sparse crates.io protocol in rustdoc GitHub Actions workflow

### DIFF
--- a/github-org-artichoke/repository_file_github_actions_rustdoc_workflow.tf
+++ b/github-org-artichoke/repository_file_github_actions_rustdoc_workflow.tf
@@ -2,7 +2,7 @@ locals {
   // Set `force_bump_...` to true to create branches for PRs that update the
   // rustdoc Documentation workflow organization-wide.
 
-  force_bump_rustdoc = false
+  force_bump_rustdoc = true
   rustdoc_repos = [
     // artichoke has custom bits that are manually managed.
     // playground does not deploy rustdoc to GitHub Pages.

--- a/github-org-artichoke/repository_file_github_actions_rustdoc_workflow.tf
+++ b/github-org-artichoke/repository_file_github_actions_rustdoc_workflow.tf
@@ -2,7 +2,7 @@ locals {
   // Set `force_bump_...` to true to create branches for PRs that update the
   // rustdoc Documentation workflow organization-wide.
 
-  force_bump_rustdoc = true
+  force_bump_rustdoc = false
   rustdoc_repos = [
     // artichoke has custom bits that are manually managed.
     // playground does not deploy rustdoc to GitHub Pages.

--- a/github-org-artichoke/templates/rustdoc-workflow.yaml
+++ b/github-org-artichoke/templates/rustdoc-workflow.yaml
@@ -11,6 +11,8 @@ name: Documentation
     - cron: "0 0 * * TUE"
 concurrency:
   group: docs-${{ github.head_ref }}
+env:
+  CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
 jobs:
   rustdoc:
     name: Build Rust API docs


### PR DESCRIPTION
https://doc.rust-lang.org/cargo/reference/config.html#registriescrates-ioprotocol

See:

- https://github.com/artichoke/artichoke/pull/2501
- https://github.com/artichoke/docker-artichoke-nightly/pull/148

This should speed up build times.

## Deployments

- https://github.com/artichoke/boba/pull/193
- https://github.com/artichoke/cactusref/pull/151
- https://github.com/artichoke/focaccia/pull/182
- https://github.com/artichoke/intaglio/pull/208
- https://github.com/artichoke/posix-space/pull/33
- https://github.com/artichoke/qed/pull/50
- https://github.com/artichoke/rand_mt/pull/185
- https://github.com/artichoke/raw-parts/pull/75
- https://github.com/artichoke/roe/pull/126
- https://github.com/artichoke/ruby-file-expand-path/pull/62
- https://github.com/artichoke/strftime-ruby/pull/91
- https://github.com/artichoke/strudel/pull/146