### PR TITLE
Manage lib-ruby-parser fork with Terraform

### DIFF
--- a/github-org-artichoke/repos_forks.tf
+++ b/github-org-artichoke/repos_forks.tf
@@ -1,4 +1,38 @@
 # tfsec:ignore:github-repositories-enable_vulnerability_alerts
+resource "github_repository" "lib_ruby_parser" {
+  name        = "lib-ruby-parser"
+  description = "Artichoke fork of lib-ruby-parser, a Ruby parser written in Rust"
+
+  visibility = "public"
+
+  has_downloads = false
+  has_issues    = true
+  has_projects  = false
+  has_wiki      = false
+
+  delete_branch_on_merge = true
+  vulnerability_alerts   = false
+
+  topics = [
+    "artichoke",
+    "fork",
+    "parser",
+    "ruby",
+    "rust",
+    "vendor"
+  ]
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "github_actions_repository_permissions" "lib_ruby_parser" {
+  repository = github_repository.lib_ruby_parser.name
+  enabled    = false
+}
+
+# tfsec:ignore:github-repositories-enable_vulnerability_alerts
 resource "github_repository" "mruby" {
   name        = "mruby"
   description = "Artichoke fork of mruby 3.x, a Lightweight Ruby"


### PR DESCRIPTION
Fixes #455.

This change is applied:

```
Terraform will perform the following actions:

  # github_repository.lib_ruby_parser will be updated in-place
  ~ resource "github_repository" "lib_ruby_parser" {
      ~ delete_branch_on_merge      = false -> true
      ~ description                 = "Ruby parser written in Rust" -> "Artichoke fork of lib-ruby-parser, a Ruby parser written in Rust"
      ~ has_downloads               = true -> false
      ~ has_issues                  = false -> true
      ~ has_projects                = true -> false
      ~ has_wiki                    = true -> false
        id                          = "lib-ruby-parser"
        name                        = "lib-ruby-parser"
      ~ topics                      = [
          + "artichoke",
          + "fork",
          + "parser",
          + "ruby",
          + "rust",
          + "vendor",
        ]
        # (26 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

github_repository.lib_ruby_parser: Modifying... [id=lib-ruby-parser]
github_repository.lib_ruby_parser: Modifications complete after 5s [id=lib-ruby-parser]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```