### PR TITLE
Track that org-wide Ruby version is 3.2.2

### DIFF
--- a/github-org-artichoke/repository_file_ruby_version.tf
+++ b/github-org-artichoke/repository_file_ruby_version.tf
@@ -1,8 +1,8 @@
 locals {
   force_bump_ruby_version = false
 
-  // https://github.com/ruby/ruby/tree/v3_1_2
-  ruby_version = "3.1.2"
+  // https://github.com/ruby/ruby/tree/v3_2_2
+  ruby_version = "3.2.2"
 
   ruby_version_repos = [
     "artichoke",                // https://github.com/artichoke/artichoke


### PR DESCRIPTION
These changes were already rolled out manually (along with bundler upgrades and RuboCop config changes):

- https://github.com/artichoke/artichoke/pull/2519
- https://github.com/artichoke/artichoke.github.io/pull/129
- https://github.com/artichoke/boba/pull/194
- https://github.com/artichoke/cactusref/pull/155
- https://github.com/artichoke/docker-artichoke-nightly/pull/154
- https://github.com/artichoke/focaccia/pull/184
- https://github.com/artichoke/intaglio/pull/213
- https://github.com/artichoke/nightly/pull/156
- https://github.com/artichoke/playground/pull/1038
- https://github.com/artichoke/posix-space/pull/35
- https://github.com/artichoke/qed/pull/57
- https://github.com/artichoke/rand_mt/pull/187
- https://github.com/artichoke/raw-parts/pull/77
- https://github.com/artichoke/roe/pull/127
- https://github.com/artichoke/rubyconf/pull/474
- https://github.com/artichoke/ruby-file-expand-path/pull/64
- https://github.com/artichoke/strftime-ruby/pull/93
- https://github.com/artichoke/strudel/pull/147
- https://github.com/artichoke/project-infrastructure/pull/463