### PR TITLE
Use stricter version pinning for GitHub Actions

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.2
 
       - name: Install Ruby toolchain
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@6cecb48364174b0952995175c55f9bf5527e6682 # v1.147.0
         with:
           ruby-version: ".ruby-version"
           bundler-cache: true

--- a/.github/workflows/block-merge.yaml
+++ b/.github/workflows/block-merge.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: mheap/github-action-required-labels@v3
+      - uses: mheap/github-action-required-labels@422e4c352ef83db91089e6acfbf09d8725e08abc # v4.0.0
         with:
           mode: exactly
           count: 0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,10 +19,10 @@ jobs:
     # https://www.terraform.io/docs/github-actions/getting-started.html
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.2
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@master
+        uses: aws-actions/configure-aws-credentials@e1e17a757e536f70e52b5a12b2e8d1d1c60e04ef # v2.0.0
         with:
           aws-region: us-west-2
           role-to-assume: arn:aws:iam::447522982029:role/gha-project-infrastructure-s3-ro-20220212013048188700000001
@@ -32,7 +32,7 @@ jobs:
         run: aws sts get-caller-identity
 
       - name: "Setup Terraform"
-        uses: hashicorp/setup-terraform@v2
+        uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
           terraform_version: 1.x
 
@@ -74,10 +74,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.2
 
       - name: Install Ruby toolchain
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@6cecb48364174b0952995175c55f9bf5527e6682 # v1.147.0
         with:
           ruby-version: ".ruby-version"
           bundler-cache: true
@@ -90,7 +90,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.2
 
       - name: Lint and check formatting with prettier
         run: npx prettier --check '**/*'

--- a/.github/workflows/markdown-link-check.yaml
+++ b/.github/workflows/markdown-link-check.yaml
@@ -23,10 +23,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.2
 
       - name: Check for broken links in markdown files
-        uses: gaurav-nelson/github-action-markdown-link-check@v1
+        uses: gaurav-nelson/github-action-markdown-link-check@d53a906aa6b22b8979d33bc86170567e619495ec # v1.0.15
         with:
           use-quiet-mode: "yes"
           use-verbose-mode: "yes"

--- a/.github/workflows/repo-labels.yaml
+++ b/.github/workflows/repo-labels.yaml
@@ -20,10 +20,10 @@ jobs:
     name: Synchronize repository labels
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3.5.2
 
       - name: Sync GitHub Issue Labels
-        uses: crazy-max/ghaction-github-labeler@v4
+        uses: crazy-max/ghaction-github-labeler@3de87da19416edc45c90cd89e7a4ea922a3aae5a # v4.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           yaml-file: .github/labels.yaml

--- a/.github/workflows/tfsec.yaml
+++ b/.github/workflows/tfsec.yaml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.2
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@master
+        uses: aws-actions/configure-aws-credentials@e1e17a757e536f70e52b5a12b2e8d1d1c60e04ef # v2.0.0
         with:
           aws-region: us-west-2
           role-to-assume: arn:aws:iam::447522982029:role/gha-project-infrastructure-s3-ro-20220212013048188700000001
@@ -32,7 +32,7 @@ jobs:
         run: aws sts get-caller-identity
 
       - name: "Setup Terraform"
-        uses: hashicorp/setup-terraform@v2
+        uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
           terraform_version: 1.x
 

--- a/github-org-artichoke/templates/audit-workflow-node-ruby-rust.yaml
+++ b/github-org-artichoke/templates/audit-workflow-node-ruby-rust.yaml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.2
 
       - name: Install Nodejs toolchain
         run: npm ci
@@ -30,10 +30,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.2
 
       - name: Install Ruby toolchain
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@6cecb48364174b0952995175c55f9bf5527e6682 # v1.147.0
         with:
           ruby-version: ".ruby-version"
           bundler-cache: true
@@ -55,10 +55,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.2
 
       - name: Install Rust toolchain
-        uses: artichoke/setup-rust/audit@v1
+        uses: artichoke/setup-rust/audit@v1.9.0
 
       - name: Generate Cargo.lock
         run: |
@@ -66,7 +66,7 @@ jobs:
             cargo generate-lockfile --verbose
           fi
 
-      - uses: EmbarkStudios/cargo-deny-action@v1
+      - uses: EmbarkStudios/cargo-deny-action@e0a440755b184aa50374330fa75cca0f84fcb59a # v1.5.2
         with:
           arguments: --locked --all-features
           command: check ${{ matrix.checks }}

--- a/github-org-artichoke/templates/audit-workflow-node-ruby.yaml
+++ b/github-org-artichoke/templates/audit-workflow-node-ruby.yaml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.2
 
       - name: Install Nodejs toolchain
         run: npm ci
@@ -30,10 +30,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.2
 
       - name: Install Ruby toolchain
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@6cecb48364174b0952995175c55f9bf5527e6682 # v1.147.0
         with:
           ruby-version: ".ruby-version"
           bundler-cache: true

--- a/github-org-artichoke/templates/audit-workflow-node.yaml
+++ b/github-org-artichoke/templates/audit-workflow-node.yaml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.2
 
       - name: Install Nodejs toolchain
         run: npm ci

--- a/github-org-artichoke/templates/audit-workflow-ruby-rust.yaml
+++ b/github-org-artichoke/templates/audit-workflow-ruby-rust.yaml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.2
 
       - name: Install Ruby toolchain
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@6cecb48364174b0952995175c55f9bf5527e6682 # v1.147.0
         with:
           ruby-version: ".ruby-version"
           bundler-cache: true
@@ -41,10 +41,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.2
 
       - name: Install Rust toolchain
-        uses: artichoke/setup-rust/audit@v1
+        uses: artichoke/setup-rust/audit@v1.9.0
 
       - name: Generate Cargo.lock
         run: |
@@ -52,7 +52,7 @@ jobs:
             cargo generate-lockfile --verbose
           fi
 
-      - uses: EmbarkStudios/cargo-deny-action@v1
+      - uses: EmbarkStudios/cargo-deny-action@e0a440755b184aa50374330fa75cca0f84fcb59a # v1.5.2
         with:
           arguments: --locked --all-features
           command: check ${{ matrix.checks }}

--- a/github-org-artichoke/templates/audit-workflow-ruby.yaml
+++ b/github-org-artichoke/templates/audit-workflow-ruby.yaml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.2
 
       - name: Install Ruby toolchain
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@6cecb48364174b0952995175c55f9bf5527e6682 # v1.147.0
         with:
           ruby-version: ".ruby-version"
           bundler-cache: true

--- a/github-org-artichoke/templates/rust-code-coverage.yaml
+++ b/github-org-artichoke/templates/rust-code-coverage.yaml
@@ -19,10 +19,10 @@ jobs:
       CARGO_NET_GIT_FETCH_WITH_CLI: true
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.2
 
       - name: Install nightly Rust toolchain
-        uses: artichoke/setup-rust/code-coverage@v1
+        uses: artichoke/setup-rust/code-coverage@v1.9.0
 
       - name: Setup grcov
         run: |
@@ -57,7 +57,7 @@ jobs:
         run: grcov ${github_repository}*.profraw --source-dir . --keep-only 'src/**/*.rs' --binary-path target/debug -t covdir --filter covered -o target/coverage/coverage.json
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@master
+        uses: aws-actions/configure-aws-credentials@e1e17a757e536f70e52b5a12b2e8d1d1c60e04ef # v2.0.0
         if: github.ref == 'refs/heads/trunk'
         with:
           aws-region: us-west-2

--- a/github-org-artichoke/templates/rustdoc-workflow.yaml
+++ b/github-org-artichoke/templates/rustdoc-workflow.yaml
@@ -23,10 +23,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.2
 
       - name: Install Rust toolchain
-        uses: artichoke/setup-rust/rustdoc@v1
+        uses: artichoke/setup-rust/rustdoc@v1.9.0
 
       - name: Check docs with no default features
         run: cargo doc --workspace --no-default-features
@@ -38,7 +38,7 @@ jobs:
         run: cargo doc --workspace
 
       - name: Deploy Docs
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847 # v3.9.2
         if: github.ref == 'refs/heads/trunk'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/github-org-artichoke/templates/s3-backup.yaml
+++ b/github-org-artichoke/templates/s3-backup.yaml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.2
 
       - name: Install python-github-backup
         run: pip install github-backup==${python_github_backup_version}
@@ -75,7 +75,7 @@ jobs:
             --private
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@master
+        uses: aws-actions/configure-aws-credentials@e1e17a757e536f70e52b5a12b2e8d1d1c60e04ef # v2.0.0
         with:
           aws-region: us-west-2
           role-to-assume: ${backup_role_arn}


### PR DESCRIPTION
Pin actions from the @actions and @artichoke orgs with full git tags. Pin all other actions with git SHA corresponding to a tag.