### PR TITLE
Manage sysdir-rs repository with terraform

### DIFF
--- a/github-org-artichoke/repos_active.tf
+++ b/github-org-artichoke/repos_active.tf
@@ -449,6 +449,26 @@ module "github_strudel" {
   ]
 }
 
+module "github_sysdir" {
+  source = "../modules/github-repository"
+
+  name         = "sysdir-rs"
+  description  = "🍎 📁 Rust bindings to `sysdir` API on Apple platforms"
+  homepage_url = "https://crates.io/crates/sysdir"
+
+  topics = [
+    "bindgen",
+    "ios",
+    "knownfolders",
+    "macos",
+    "rust",
+    "rust-crate",
+    "sysdir",
+    "tvos",
+    "watchos",
+  ]
+}
+
 module "github_www_artichokeruby_org" {
   source = "../modules/github-repository"
 


### PR DESCRIPTION
These changes are applied:

```
Terraform will perform the following actions:

  # module.archived_artichoke_ci.github_repository.this will be updated in-place
  ~ resource "github_repository" "this" {
      ~ has_projects                = true -> false
        id                          = "artichoke-ci"
        name                        = "artichoke-ci"
        # (32 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }

  # module.archived_ferrocarril.github_repository.this will be updated in-place
  ~ resource "github_repository" "this" {
      ~ has_projects                = true -> false
        id                          = "ferrocarril"
        name                        = "ferrocarril"
        # (33 unchanged attributes hidden)

        # (2 unchanged blocks hidden)
    }

  # module.archived_rubyconf2019_artichoke_run.github_repository.this will be updated in-place
  ~ resource "github_repository" "this" {
      ~ has_projects                = true -> false
        id                          = "rubyconf2019.artichoke.run"
        name                        = "rubyconf2019.artichoke.run"
        # (33 unchanged attributes hidden)

        # (2 unchanged blocks hidden)
    }

  # module.archived_rust_mersenne_twister.github_repository.this will be updated in-place
  ~ resource "github_repository" "this" {
      ~ has_projects                = true -> false
        id                          = "rust-mersenne-twister"
        name                        = "rust-mersenne-twister"
      ~ topics                      = [
          + "artichoke",
        ]
        # (32 unchanged attributes hidden)

        # (2 unchanged blocks hidden)
    }

  # module.github_sysdir.github_actions_repository_permissions.this will be created
  + resource "github_actions_repository_permissions" "this" {
      + allowed_actions = "all"
      + enabled         = true
      + id              = (known after apply)
      + repository      = "sysdir-rs"
    }

  # module.github_sysdir.github_repository.this will be updated in-place
  ~ resource "github_repository" "this" {
      ~ has_projects                = true -> false
        id                          = "sysdir-rs"
        name                        = "sysdir-rs"
      ~ squash_merge_commit_message = "COMMIT_MESSAGES" -> "PR_BODY"
      ~ squash_merge_commit_title   = "COMMIT_OR_PR_TITLE" -> "PR_TITLE"
      ~ topics                      = [
          + "artichoke",
          + "bindgen",
          + "ios",
          + "knownfolders",
          + "macos",
          + "rust",
          + "rust-crate",
          + "sysdir",
          + "tvos",
          + "watchos",
        ]
        # (30 unchanged attributes hidden)

        # (2 unchanged blocks hidden)
    }

Plan: 1 to add, 5 to change, 0 to destroy.
```