### PR TITLE
Improve codecov GitHub Actions workflow

### DIFF
--- a/github-org-artichoke/repository_file_github_actions_rust_code_coverage_workflow.tf
+++ b/github-org-artichoke/repository_file_github_actions_rust_code_coverage_workflow.tf
@@ -1,6 +1,6 @@
 locals {
-  // Set `force_bump_s3_backup` to true to create branches for PRs that update
-  // the S3 backup workflow organization-wide.
+  // Set `force_bump_rust_code_coverage` to true to create branches for PRs that
+  // update the Rust code coverage workflow organization-wide.
 
   force_bump_rust_code_coverage = false
   rust_code_coverage_repos = [

--- a/github-org-artichoke/repository_file_github_actions_rust_code_coverage_workflow.tf
+++ b/github-org-artichoke/repository_file_github_actions_rust_code_coverage_workflow.tf
@@ -2,7 +2,7 @@ locals {
   // Set `force_bump_s3_backup` to true to create branches for PRs that update
   // the S3 backup workflow organization-wide.
 
-  force_bump_rust_code_coverage = true
+  force_bump_rust_code_coverage = false
   rust_code_coverage_repos = [
     "boba",          // https://github.com/artichoke/boba
     "focaccia",      // https://github.com/artichoke/focaccia

--- a/github-org-artichoke/repository_file_github_actions_rust_code_coverage_workflow.tf
+++ b/github-org-artichoke/repository_file_github_actions_rust_code_coverage_workflow.tf
@@ -2,7 +2,7 @@ locals {
   // Set `force_bump_s3_backup` to true to create branches for PRs that update
   // the S3 backup workflow organization-wide.
 
-  force_bump_rust_code_coverage = false
+  force_bump_rust_code_coverage = true
   rust_code_coverage_repos = [
     "boba",          // https://github.com/artichoke/boba
     "focaccia",      // https://github.com/artichoke/focaccia

--- a/github-org-artichoke/templates/rust-code-coverage.yaml
+++ b/github-org-artichoke/templates/rust-code-coverage.yaml
@@ -47,7 +47,10 @@ jobs:
         env:
           LLVM_PROFILE_FILE: "${github_repository}-%m-%p.profraw"
           RUSTFLAGS: "-C instrument-coverage"
-          # Unstable feature: https://github.com/rust-lang/rust/issues/56925
+          # Unstable feature: `--persist-doctests`: persist doctest executables after running
+          # https://rustwiki.org/en/rustdoc/unstable-features.html#--persist-doctests-persist-doctest-executables-after-running
+          #
+          # Used to allow grcov to use these sources to generate coverage metrics.
           RUSTDOCFLAGS: "-C instrument-coverage -Z unstable-options --persist-doctests target/debug/doctests"
         run: cargo test
 

--- a/github-org-artichoke/templates/rust-code-coverage.yaml
+++ b/github-org-artichoke/templates/rust-code-coverage.yaml
@@ -17,6 +17,7 @@ jobs:
     env:
       RUST_BACKTRACE: 1
       CARGO_NET_GIT_FETCH_WITH_CLI: true
+      CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3.5.2

--- a/github-org-artichoke/templates/rust-code-coverage.yaml
+++ b/github-org-artichoke/templates/rust-code-coverage.yaml
@@ -81,26 +81,43 @@ jobs:
           aws s3 sync target/coverage/ s3://${s3_bucket}/${github_repository}/ --delete --sse AES256 --include '*' --exclude '*.svg' --exclude '*.html' --exclude '*.json'
 
       - name: Check missed lines
+        shell: python
         run: |
-          curl -s https://codecov.artichokeruby.org/${github_repository}/coverage.json | python -c '\
-          import sys, json; \
-          \
-          trunk_coverage = json.loads(sys.stdin.read()); \
-          print("On trunk: "); \
-          print("coveragePercent =", trunk_coverage["coveragePercent"]); \
-          print("linesCovered =", trunk_coverage["linesCovered"]); \
-          print("linesMissed =", trunk_coverage["linesMissed"]); \
-          print("linesTotal =", trunk_coverage["linesTotal"]); \
-          print(""); \
-          \
-          branch_coverage = json.load(open("target/coverage/coverage.json"))
-          print("On PR branch: "); \
-          print("coveragePercent =", branch_coverage["coveragePercent"]); \
-          print("linesCovered =", branch_coverage["linesCovered"]); \
-          print("linesMissed =", branch_coverage["linesMissed"]); \
-          print("linesTotal =", branch_coverage["linesTotal"]); \
-          print(""); \
-          \
-          is_ok = branch_coverage["linesMissed"] <= trunk_coverage["linesMissed"]; \
-          exit(0) if is_ok else exit(1) \
-          '
+          import json
+          from urllib.request import urlopen
+
+          trunk_coverage_url = "https://codecov.artichokeruby.org/${github_repository}/coverage.json"
+
+
+          def print_report(coverage, *, on=None):
+              if on is None:
+                  raise ValueError("must provide `on` kwarg")
+
+              print(f"On {on}:")
+              print("coveragePercent =", coverage["coveragePercent"])
+              print("linesCovered =", coverage["linesCovered"])
+              print("linesMissed =", coverage["linesMissed"])
+              print("linesTotal =", coverage["linesTotal"])
+              print("")
+
+
+          if "$${{ github.ref_name }}" == "trunk":
+              # We don't need to compare trunk coverage to itself
+              exit(0)
+
+          with urlopen(trunk_coverage_url, data=None, timeout=3) as remote:
+              trunk_coverage = json.load(remote)
+
+          print_report(trunk_coverage, on="branch trunk")
+
+          with open("target/coverage/coverage.json") as local:
+              branch_coverage = json.load(local)
+
+          on = None
+          if "$${{ github.event_name }}" == "pull_request":
+              on = "PR artichoke/${github_repository}#$${{ github.event.number }}"
+
+          print_report(branch_coverage, on=on)
+
+          is_ok = branch_coverage["linesMissed"] <= trunk_coverage["linesMissed"]
+          exit(0) if is_ok else exit(1)


### PR DESCRIPTION
- Use crates.io registry sparse protocol in codecov workflow
- Document use of unstable rustdoc feature in a way that doesn't spam the tracking issue
- Rewrite 'check missed lines' step using a 'python' shell

## Deployments

- https://github.com/artichoke/boba/pull/199
- https://github.com/artichoke/focaccia/pull/189
- https://github.com/artichoke/intaglio/pull/218
- https://github.com/artichoke/posix-space/pull/40
- https://github.com/artichoke/rand_mt/pull/193
- https://github.com/artichoke/raw-parts/pull/82
- https://github.com/artichoke/roe/pull/132
- https://github.com/artichoke/strftime-ruby/pull/98