### PR TITLE
Manage GitHub organization settings with terraform

### DIFF
--- a/github-org-artichoke-ruby/main.tf
+++ b/github-org-artichoke-ruby/main.tf
@@ -8,6 +8,33 @@ terraform {
   }
 }
 
+resource "github_organization_settings" "this" {
+  billing_email                                                = "github-billing@artichokeruby.org"
+  blog                                                         = "https://www.artichokeruby.org"
+  email                                                        = "github@artichokeruby.org"
+  twitter_username                                             = "artichokeruby"
+  name                                                         = "Artichoke Ruby (alternate)"
+  description                                                  = "Alternate GitHub organization for artichoke to protect against typosquatting"
+  has_organization_projects                                    = false
+  has_repository_projects                                      = false
+  default_repository_permission                                = "read"
+  members_can_create_repositories                              = true
+  members_can_create_public_repositories                       = true
+  members_can_create_private_repositories                      = true
+  members_can_create_internal_repositories                     = false
+  members_can_create_pages                                     = true
+  members_can_create_public_pages                              = true
+  members_can_create_private_pages                             = true
+  members_can_fork_private_repositories                        = false
+  web_commit_signoff_required                                  = false
+  advanced_security_enabled_for_new_repositories               = false
+  dependabot_alerts_enabled_for_new_repositories               = true
+  dependabot_security_updates_enabled_for_new_repositories     = true
+  dependency_graph_enabled_for_new_repositories                = true
+  secret_scanning_enabled_for_new_repositories                 = true
+  secret_scanning_push_protection_enabled_for_new_repositories = true
+}
+
 module "security_events_webhook" {
   source = "../modules/github-discord-webhook"
 

--- a/github-org-artichoke/main.tf
+++ b/github-org-artichoke/main.tf
@@ -25,6 +25,33 @@ data "terraform_remote_state" "aws" {
   }
 }
 
+resource "github_organization_settings" "this" {
+  billing_email                                                = "github-billing@artichokeruby.org"
+  blog                                                         = "https://www.artichokeruby.org"
+  email                                                        = "github@artichokeruby.org"
+  twitter_username                                             = "artichokeruby"
+  name                                                         = "Artichoke Ruby"
+  description                                                  = "Artichoke is a Ruby made with Rust"
+  has_organization_projects                                    = false
+  has_repository_projects                                      = false
+  default_repository_permission                                = "read"
+  members_can_create_repositories                              = true
+  members_can_create_public_repositories                       = true
+  members_can_create_private_repositories                      = true
+  members_can_create_internal_repositories                     = false
+  members_can_create_pages                                     = true
+  members_can_create_public_pages                              = true
+  members_can_create_private_pages                             = true
+  members_can_fork_private_repositories                        = false
+  web_commit_signoff_required                                  = false
+  advanced_security_enabled_for_new_repositories               = false
+  dependabot_alerts_enabled_for_new_repositories               = true
+  dependabot_security_updates_enabled_for_new_repositories     = true
+  dependency_graph_enabled_for_new_repositories                = true
+  secret_scanning_enabled_for_new_repositories                 = true
+  secret_scanning_push_protection_enabled_for_new_repositories = true
+}
+
 module "git_events_webhook" {
   source = "../modules/github-discord-webhook"
 

--- a/github-org-artichokeruby/main.tf
+++ b/github-org-artichokeruby/main.tf
@@ -8,6 +8,33 @@ terraform {
   }
 }
 
+resource "github_organization_settings" "this" {
+  billing_email                                                = "github-billing@artichokeruby.org"
+  blog                                                         = "https://www.artichokeruby.org"
+  email                                                        = "github@artichokeruby.org"
+  twitter_username                                             = "artichokeruby"
+  name                                                         = "Artichoke Ruby (alternate)"
+  description                                                  = "Alternate GitHub organization for artichoke to protect a package scope"
+  has_organization_projects                                    = false
+  has_repository_projects                                      = false
+  default_repository_permission                                = "read"
+  members_can_create_repositories                              = true
+  members_can_create_public_repositories                       = true
+  members_can_create_private_repositories                      = true
+  members_can_create_internal_repositories                     = false
+  members_can_create_pages                                     = true
+  members_can_create_public_pages                              = true
+  members_can_create_private_pages                             = true
+  members_can_fork_private_repositories                        = false
+  web_commit_signoff_required                                  = false
+  advanced_security_enabled_for_new_repositories               = false
+  dependabot_alerts_enabled_for_new_repositories               = true
+  dependabot_security_updates_enabled_for_new_repositories     = true
+  dependency_graph_enabled_for_new_repositories                = true
+  secret_scanning_enabled_for_new_repositories                 = true
+  secret_scanning_push_protection_enabled_for_new_repositories = true
+}
+
 module "security_events_webhook" {
   source = "../modules/github-discord-webhook"
 


### PR DESCRIPTION
Fixes https://github.com/artichoke/project-infrastructure/issues/386.

Rolled out changes to @artichoke, @artichoke-ruby, and @artichokeruby organizations.

Only changes were to disable organization projects and disable repository projects org-wide.

These changes are applied.