### PR TITLE
Delete `.dev` domains

### DIFF
--- a/docs/domains.md
+++ b/docs/domains.md
@@ -4,10 +4,8 @@
 
 | Domain            | Registrar      | DNS            | DNSSEC? | MX Records[^1]? |
 | ----------------- | -------------- | -------------- | ------- | --------------- |
-| artichoke.dev     | Google Domains | None           | ✅      | ❌              |
 | artichoke.run     | Google Domains | Google Domains | ✅      | ❌              |
 | artichokeruby.com | Google Domains | Google Domains | ✅      | ❌              |
-| artichokeruby.dev | Google Domains | None           | ✅      | ❌              |
 | artichokeruby.net | Google Domains | Google Domains | ✅      | ❌              |
 | artichokeruby.org | Google Domains | Google Domains | ✅      | ✅              |
 | artichokeruby.run | Google Domains | Google Domains | ✅      | ❌              |


### PR DESCRIPTION
`artichoke.dev` and `artichokeruby.dev` domain registrations have been deleted.

As part of addressing https://github.com/artichoke/project-infrastructure/issues/519, all Artichoke domain registrations are moving to AWS Route53 Domains.

AWS does not support `.dev`. Combined with no usage of these domains, delete them. This will save some $ per year and allow vendor consolidation.