### PR TITLE
Document disabling of DNSSEC

### DIFF
--- a/docs/domains.md
+++ b/docs/domains.md
@@ -4,11 +4,11 @@
 
 | Domain            | Registrar      | DNS            | DNSSEC? | MX Records[^1]? |
 | ----------------- | -------------- | -------------- | ------- | --------------- |
-| artichoke.run     | Google Domains | Google Domains | ✅      | ❌              |
-| artichokeruby.com | Google Domains | Google Domains | ✅      | ❌              |
-| artichokeruby.net | Google Domains | Google Domains | ✅      | ❌              |
-| artichokeruby.org | Google Domains | Google Domains | ✅      | ✅              |
-| artichokeruby.run | Google Domains | Google Domains | ✅      | ❌              |
+| artichoke.run     | Google Domains | Google Domains | ❌      | ❌              |
+| artichokeruby.com | Google Domains | Google Domains | ❌      | ❌              |
+| artichokeruby.net | Google Domains | Google Domains | ❌      | ❌              |
+| artichokeruby.org | Google Domains | Google Domains | ❌      | ✅              |
+| artichokeruby.run | Google Domains | Google Domains | ❌      | ❌              |
 
 [^1]: MX records are also linked to a Google Workspace account.
 


### PR DESCRIPTION
To address https://github.com/artichoke/project-infrastructure/issues/519, disable DNSSEC to make migration easier.

As of June 19, 2023, all zones are unpublished and unsigned in Google Domains.