### PR TITLE
Migrate DNS for "redirect" domain names to Route53

### DIFF
--- a/aws/dns.tf
+++ b/aws/dns.tf
@@ -1,1 +1,0 @@
-# DNS is managed by Google Domains (registrar of Artichoke domains).

--- a/aws/dns_artichokeruby.com.tf
+++ b/aws/dns_artichokeruby.com.tf
@@ -1,0 +1,51 @@
+locals {
+  artichokeruby_com_github_challenges = [
+    { org = "artichoke", domain = "artichokeruby.com", challenge = "b2f4638e51" },
+    { org = "artichoke", domain = "www.artichokeruby.com", challenge = "2fec52406f" },
+    { org = "artichokeruby", domain = "artichokeruby.com", challenge = "ca289d9cc6" },
+    { org = "artichokeruby", domain = "www.artichokeruby.com", challenge = "4ed7a6a51e" },
+    { org = "artichoke-ruby-org", domain = "artichokeruby.com", challenge = "52fff25586" },
+    { org = "artichoke-ruby-org", domain = "www.artichokeruby.com", challenge = "2f65a1a84d" },
+  ]
+}
+
+resource "aws_route53_zone" "artichokeruby_com" {
+  name = "artichokeruby.com"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+module "artichokeruby_com_github_challenge" {
+  source   = "../modules/github-domain-verification"
+  for_each = { for conf in local.artichokeruby_com_github_challenges : "${conf.org}_${conf.domain}" => conf }
+
+  zone_id             = aws_route53_zone.artichokeruby_com.zone_id
+  github_organization = each.value.org
+  domain              = each.value.domain
+  challenge           = each.value.challenge
+}
+
+module "artichokeruby_com_github_pages_challenge" {
+  source = "../modules/github-pages-domain-verification"
+
+  zone_id             = aws_route53_zone.artichokeruby_com.zone_id
+  github_organization = "artichoke"
+  domain              = "artichokeruby.com"
+  challenge           = "cef8b209bccd79f7df0f51b877bd9e"
+}
+
+module "artichokeruby_com_redirect" {
+  source = "../modules/domain-redirect"
+
+  access_logs_bucket = module.forge_access_logs.name
+
+  zone_id     = aws_route53_zone.artichokeruby_com.zone_id
+  redirect_to = "https://www.artichokeruby.org"
+
+  providers = {
+    aws           = aws
+    aws.us_east_1 = aws.us_east_1
+  }
+}

--- a/aws/dns_artichokeruby.net.tf
+++ b/aws/dns_artichokeruby.net.tf
@@ -19,7 +19,7 @@ resource "aws_route53_zone" "artichokeruby_net" {
 
 module "artichokeruby_net_github_challenge" {
   source   = "../modules/github-domain-verification"
-  for_each = {for conf in local.artichokeruby_net_github_challenges : "${conf.org}_${conf.domain}" => conf}
+  for_each = { for conf in local.artichokeruby_net_github_challenges : "${conf.org}_${conf.domain}" => conf }
 
   zone_id             = aws_route53_zone.artichokeruby_net.zone_id
   github_organization = each.value.org

--- a/aws/dns_artichokeruby.net.tf
+++ b/aws/dns_artichokeruby.net.tf
@@ -39,6 +39,8 @@ module "artichokeruby_net_github_pages_challenge" {
 module "artichokeruby_net_redirect" {
   source = "../modules/domain-redirect"
 
+  access_logs_bucket = module.forge_access_logs.name
+
   zone_id     = aws_route53_zone.artichokeruby_net.zone_id
   redirect_to = "https://www.artichokeruby.org"
 

--- a/aws/dns_artichokeruby.net.tf
+++ b/aws/dns_artichokeruby.net.tf
@@ -35,3 +35,15 @@ module "artichokeruby_net_github_pages_challenge" {
   domain              = "artichokeruby.net"
   challenge           = "7da729a45019ca339d0cedce912c2e"
 }
+
+module "artichokeruby_net_redirect" {
+  source = "../modules/domain-redirect"
+
+  zone_id     = aws_route53_zone.artichokeruby_net.zone_id
+  redirect_to = "https://www.artichokeruby.org"
+
+  providers = {
+    aws           = aws
+    aws.us_east_1 = aws.us_east_1
+  }
+}

--- a/aws/dns_artichokeruby.net.tf
+++ b/aws/dns_artichokeruby.net.tf
@@ -1,0 +1,37 @@
+locals {
+  artichokeruby_net_github_challenges = [
+    { org = "artichoke", domain = "artichokeruby.net", challenge = "40284224b9" },
+    { org = "artichoke", domain = "www.artichokeruby.net", challenge = "4970552f6c" },
+    { org = "artichokeruby", domain = "artichokeruby.net", challenge = "7a2a1dc233" },
+    { org = "artichokeruby", domain = "www.artichokeruby.net", challenge = "3113b923f8" },
+    { org = "artichoke-ruby-org", domain = "artichokeruby.net", challenge = "98600a94a6" },
+    { org = "artichoke-ruby-org", domain = "www.artichokeruby.net", challenge = "f82ad5d5e8" },
+  ]
+}
+
+resource "aws_route53_zone" "artichokeruby_net" {
+  name = "artichokeruby.net"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+module "artichokeruby_net_github_challenge" {
+  source   = "../modules/github-domain-verification"
+  for_each = {for conf in local.artichokeruby_net_github_challenges : "${conf.org}_${conf.domain}" => conf}
+
+  zone_id             = aws_route53_zone.artichokeruby_net.zone_id
+  github_organization = each.value.org
+  domain              = each.value.domain
+  challenge           = each.value.challenge
+}
+
+module "artichokeruby_net_github_pages_challenge" {
+  source = "../modules/github-pages-domain-verification"
+
+  zone_id             = aws_route53_zone.artichokeruby_net.zone_id
+  github_organization = "artichoke"
+  domain              = "artichokeruby.net"
+  challenge           = "7da729a45019ca339d0cedce912c2e"
+}

--- a/aws/dns_artichokeruby.run.tf
+++ b/aws/dns_artichokeruby.run.tf
@@ -1,0 +1,51 @@
+locals {
+  artichokeruby_run_github_challenges = [
+    { org = "artichoke", domain = "artichokeruby.run", challenge = "8c1ebf9fc6" },
+    { org = "artichoke", domain = "www.artichokeruby.run", challenge = "f8dd1ad8a9" },
+    { org = "artichokeruby-org", domain = "artichokeruby.run", challenge = "d99613e00f" },
+    { org = "artichokeruby-org", domain = "www.artichokeruby.run", challenge = "6554401e36" },
+    { org = "artichoke-ruby-org", domain = "artichokeruby.run", challenge = "5d7d7290b9" },
+    { org = "artichoke-ruby-org", domain = "www.artichokeruby.run", challenge = "3e5409f8a9" },
+  ]
+}
+
+resource "aws_route53_zone" "artichokeruby_run" {
+  name = "artichokeruby.run"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+module "artichokeruby_run_github_challenge" {
+  source   = "../modules/github-domain-verification"
+  for_each = { for conf in local.artichokeruby_run_github_challenges : "${conf.org}_${conf.domain}" => conf }
+
+  zone_id             = aws_route53_zone.artichokeruby_run.zone_id
+  github_organization = each.value.org
+  domain              = each.value.domain
+  challenge           = each.value.challenge
+}
+
+module "artichokeruby_run_github_pages_challenge" {
+  source = "../modules/github-pages-domain-verification"
+
+  zone_id             = aws_route53_zone.artichokeruby_run.zone_id
+  github_organization = "artichoke"
+  domain              = "artichokeruby.run"
+  challenge           = "50369d1a13ec11c0d9899705388810"
+}
+
+module "artichokeruby_run_redirect" {
+  source = "../modules/domain-redirect"
+
+  access_logs_bucket = module.forge_access_logs.name
+
+  zone_id     = aws_route53_zone.artichokeruby_run.zone_id
+  redirect_to = "https://artichoke.run"
+
+  providers = {
+    aws           = aws
+    aws.us_east_1 = aws.us_east_1
+  }
+}

--- a/aws/email.tf
+++ b/aws/email.tf
@@ -1,1 +1,0 @@
-# email is configured using the G Suite integration in Google Domains.

--- a/docs/domains.md
+++ b/docs/domains.md
@@ -18,12 +18,12 @@
 | ---------------------------- | ---------------------------------- | ----------------------------------- | ------ | --------- |
 | [artichoke.run]              | A and AAAA records to GitHub Pages | Wasm playground                     | ✅     | ❌        |
 | [www.artichoke.run]          | CNAME to GitHub Pages              | Wasm playground redirect            | ✅     | ❌        |
+| [rubyconf2019.artichoke.run] | CNAME to GitHub Pages              | Snapshot of the Wasm playground[^3] | ✅     | ❌        |
 | [artichokeruby.com]          | CloudFront domain redirect         | Project website redirect            | ✅     | ✅        |
 | [www.artichokeruby.com]      | CloudFront domain redirect         | Project website redirect            | ✅     | ✅        |
-| [rubyconf2019.artichoke.run] | CNAME to GitHub Pages              | Snapshot of the Wasm playground[^3] | ✅     | ❌        |
 | [artichokeruby.org]          | Google-managed redirect            | Project website redirect            | ✅     | ❌        |
-| [codecov.artichokeruby.org]  | CNAME to CloudFront distribution   | Code coverage reports               | ✅     | ✅        |
 | [www.artichokeruby.org]      | CNAME to GitHub Pages              | Project website                     | ✅     | ❌        |
+| [codecov.artichokeruby.org]  | CNAME to CloudFront distribution   | Code coverage reports               | ✅     | ✅        |
 | [artichokeruby.net]          | CloudFront domain redirect         | Project website redirect            | ✅     | ✅        |
 | [www.artichokeruby.net]      | CloudFront domain redirect         | Project website redirect            | ✅     | ✅        |
 | [artichokeruby.run]          | CloudFront domain redirect         | Wasm playground website redirect    | ✅     | ✅        |
@@ -31,12 +31,12 @@
 
 [artichoke.run]: https://artichoke.run/
 [www.artichoke.run]: https://www.artichoke.run/
+[rubyconf2019.artichoke.run]: https://rubyconf2019.artichoke.run/
 [artichokeruby.com]: https://artichokeruby.com/
 [www.artichokeruby.com]: https://www.artichokeruby.com/
-[rubyconf2019.artichoke.run]: https://rubyconf2019.artichoke.run/
 [artichokeruby.org]: https://artichokeruby.org/
-[codecov.artichokeruby.org]: https://codecov.artichokeruby.org/
 [www.artichokeruby.org]: https://www.artichokeruby.org/
+[codecov.artichokeruby.org]: https://codecov.artichokeruby.org/
 [artichokeruby.net]: https://artichokeruby.net/
 [www.artichokeruby.net]: https://www.artichokeruby.net/
 [artichokeruby.run]: https://artichokeruby.run/

--- a/docs/domains.md
+++ b/docs/domains.md
@@ -2,13 +2,13 @@
 
 ## Domain Names
 
-| Domain            | Registrar      | DNS            | DNSSEC? | MX Records[^1]? |
-| ----------------- | -------------- | -------------- | ------- | --------------- |
-| artichoke.run     | Google Domains | Google Domains | ❌      | ❌              |
-| artichokeruby.com | Google Domains | Google Domains | ❌      | ❌              |
-| artichokeruby.net | Google Domains | Google Domains | ❌      | ❌              |
-| artichokeruby.org | Google Domains | Google Domains | ❌      | ✅              |
-| artichokeruby.run | Google Domains | Google Domains | ❌      | ❌              |
+| Domain            | Registrar      | DNS             | DNSSEC? | MX Records[^1]? |
+| ----------------- | -------------- | --------------- | ------- | --------------- |
+| artichoke.run     | Google Domains | Google Domains  | ❌      | ❌              |
+| artichokeruby.com | Google Domains | Amazon Route 53 | ❌      | ❌              |
+| artichokeruby.net | Google Domains | Amazon Route 53 | ❌      | ❌              |
+| artichokeruby.org | Google Domains | Google Domains  | ❌      | ✅              |
+| artichokeruby.run | Google Domains | Amazon Route 53 | ❌      | ❌              |
 
 [^1]: MX records are also linked to a Google Workspace account.
 
@@ -18,16 +18,16 @@
 | ---------------------------- | ---------------------------------- | ----------------------------------- | ------ | --------- |
 | [artichoke.run]              | A and AAAA records to GitHub Pages | Wasm playground                     | ✅     | ❌        |
 | [www.artichoke.run]          | CNAME to GitHub Pages              | Wasm playground redirect            | ✅     | ❌        |
-| [artichokeruby.com]          | Google-managed redirect            | Project website redirect            | ✅     | ❌        |
-| [www.artichokeruby.com]      | Google-managed redirect            | Project website redirect            | ✅     | ❌        |
+| [artichokeruby.com]          | CloudFront domain redirect         | Project website redirect            | ✅     | ✅        |
+| [www.artichokeruby.com]      | CloudFront domain redirect         | Project website redirect            | ✅     | ✅        |
 | [rubyconf2019.artichoke.run] | CNAME to GitHub Pages              | Snapshot of the Wasm playground[^3] | ✅     | ❌        |
 | [artichokeruby.org]          | Google-managed redirect            | Project website redirect            | ✅     | ❌        |
 | [codecov.artichokeruby.org]  | CNAME to CloudFront distribution   | Code coverage reports               | ✅     | ✅        |
 | [www.artichokeruby.org]      | CNAME to GitHub Pages              | Project website                     | ✅     | ❌        |
-| [artichokeruby.net]          | Google-managed redirect            | Project website redirect            | ✅     | ❌        |
-| [www.artichokeruby.net]      | Google-managed redirect            | Project website redirect            | ✅     | ❌        |
-| [artichokeruby.run]          | Google-managed redirect            | Wasm playground website redirect    | ✅     | ❌        |
-| [www.artichokeruby.run]      | Google-managed redirect            | Wasm playground website redirect    | ✅     | ❌        |
+| [artichokeruby.net]          | CloudFront domain redirect         | Project website redirect            | ✅     | ✅        |
+| [www.artichokeruby.net]      | CloudFront domain redirect         | Project website redirect            | ✅     | ✅        |
+| [artichokeruby.run]          | CloudFront domain redirect         | Wasm playground website redirect    | ✅     | ✅        |
+| [www.artichokeruby.run]      | CloudFront domain redirect         | Wasm playground website redirect    | ✅     | ✅        |
 
 [artichoke.run]: https://artichoke.run/
 [www.artichoke.run]: https://www.artichoke.run/

--- a/modules/acm-cert-with-dns-verification/README.md
+++ b/modules/acm-cert-with-dns-verification/README.md
@@ -1,0 +1,30 @@
+# AWS ACM Certificate with DNS Validation
+
+This folder contains a Terraform module to provision an ACM certificate using
+DNS domain ownership verification in the provided Route53 zone.
+
+## Usage
+
+```terraform
+module "cert" {
+  source = "../modules/acm-cert-with-dns-validation"
+
+  zone_id = aws_route53_zone.this.zone_id
+  domains = ["artichokeruby.org", "www.artichokeruby.org"]
+
+  providers = {
+    aws           = aws
+    aws.us_east_1 = aws.us_east_1
+  }
+}
+```
+
+## Parameters
+
+- `zone_id`: The id of the Route53 zone to create TXT records in.
+- `domains`: The domains the certificate is valid for (SANs). The first domain
+  in the list is the primary
+
+## Outputs
+
+- `cert_arn`: The ARN of the created ACM certificate.

--- a/modules/acm-cert-with-dns-verification/main.tf
+++ b/modules/acm-cert-with-dns-verification/main.tf
@@ -1,0 +1,51 @@
+locals {
+  domain_name       = var.domains[0]
+  alternative_names = slice(var.domains, 1, length(var.domains))
+}
+
+data "aws_route53_zone" "zone" {
+  zone_id = var.zone_id
+}
+
+resource "aws_acm_certificate" "this" {
+  provider = aws.us_east_1
+
+  domain_name               = local.domain_name
+  subject_alternative_names = local.alternative_names
+  validation_method         = "DNS"
+
+  # use modern cryptography
+  key_algorithm = "EC_prime256v1"
+
+  options {
+    certificate_transparency_logging_preference = "ENABLED"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_acm_certificate_validation" "this" {
+  provider = aws.us_east_1
+
+  certificate_arn         = aws_acm_certificate.this.arn
+  validation_record_fqdns = [for record in aws_route53_record.this : record.fqdn]
+}
+
+resource "aws_route53_record" "this" {
+  for_each = {
+    for dvo in aws_acm_certificate.this.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  allow_overwrite = true
+  name            = each.value.name
+  records         = [each.value.record]
+  ttl             = 60
+  type            = each.value.type
+  zone_id         = data.aws_route53_zone.zone.zone_id
+}

--- a/modules/acm-cert-with-dns-verification/outputs.tf
+++ b/modules/acm-cert-with-dns-verification/outputs.tf
@@ -1,0 +1,4 @@
+output "cert_arn" {
+  description = "The ARN of the created ACM certificate"
+  value       = aws_acm_certificate.this.arn
+}

--- a/modules/acm-cert-with-dns-verification/variables.tf
+++ b/modules/acm-cert-with-dns-verification/variables.tf
@@ -1,0 +1,9 @@
+variable "zone_id" {
+  description = "The id of the Route53 zone to create TXT records in"
+  type        = string
+}
+
+variable "domains" {
+  description = "The domains the certificate is valid for (SANs). The first domain in the list is the primary"
+  type        = list(string)
+}

--- a/modules/acm-cert-with-dns-verification/versions.tf
+++ b/modules/acm-cert-with-dns-verification/versions.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    aws = {
+      source                = "hashicorp/aws"
+      version               = "~> 4.0"
+      configuration_aliases = [aws.us_east_1]
+    }
+  }
+
+  required_version = "~> 1.0"
+}

--- a/modules/domain-redirect/README.md
+++ b/modules/domain-redirect/README.md
@@ -1,0 +1,37 @@
+# Domain Redirect
+
+This folder contains a Terraform module to CloudFront distribution which will
+redirect all requests for the given domain to another website, forwarding the
+request path. This module will set DNS records at the given domain's apex and
+www records.
+
+This module is able to replicate the "domain forwarding" feature of Google
+Domains.
+
+## Usage
+
+```terraform
+module "redirect" {
+  source = "../modules/domain-redirect"
+
+  zone_id     = aws_route53_zone.this.zone_id
+  redirect_to = "https://www.artichokeruby.org"
+
+  providers = {
+    aws           = aws
+    aws.us_east_1 = aws.us_east_1
+  }
+}
+```
+
+## Parameters
+
+- `zone_id`: The id of the Route53 zone to create redirect records in.
+- `redirect_to`: The website to redirect to, should be of the format
+  `https://example.com/`.
+
+## Outputs
+
+- `cert_arn`: The ARN of the created ACM certificate.
+- `cloudfront_domain_name`: The domain name corresponding to the CloudFront
+  distribution.

--- a/modules/domain-redirect/README.md
+++ b/modules/domain-redirect/README.md
@@ -11,8 +11,16 @@ Domains.
 ## Usage
 
 ```terraform
+module "access_logs" {
+  source = "../modules/access-logs-s3-bucket"
+
+  bucket = "artichoke-forge-logs"
+}
+
 module "redirect" {
   source = "../modules/domain-redirect"
+
+  access_logs_bucket = module.access_logs.name
 
   zone_id     = aws_route53_zone.this.zone_id
   redirect_to = "https://www.artichokeruby.org"
@@ -26,6 +34,8 @@ module "redirect" {
 
 ## Parameters
 
+- `access_logs_bucket`: The name of the bucket to use as an access logs
+  destination.
 - `zone_id`: The id of the Route53 zone to create redirect records in.
 - `redirect_to`: The website to redirect to, should be of the format
   `https://example.com/`.

--- a/modules/domain-redirect/main.tf
+++ b/modules/domain-redirect/main.tf
@@ -1,0 +1,218 @@
+locals {
+  domain = data.aws_route53_zone.zone.name
+}
+
+data "aws_route53_zone" "zone" {
+  zone_id = var.zone_id
+}
+
+resource "aws_acm_certificate" "this" {
+  provider = aws.us_east_1
+
+  domain_name               = local.domain
+  subject_alternative_names = ["www.${local.domain}"]
+  validation_method         = "DNS"
+
+  options {
+    certificate_transparency_logging_preference = "ENABLED"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_acm_certificate_validation" "this" {
+  provider = aws.us_east_1
+
+  certificate_arn         = aws_acm_certificate.this.arn
+  validation_record_fqdns = [for record in aws_route53_record.cert_validation : record.fqdn]
+}
+
+resource "aws_route53_record" "cert_validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.this.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  allow_overwrite = true
+  name            = each.value.name
+  records         = [each.value.record]
+  ttl             = 60
+  type            = each.value.type
+  zone_id         = data.aws_route53_zone.zone.zone_id
+}
+
+resource "aws_route53_record" "apex_ipv4" {
+  zone_id = data.aws_route53_zone.zone.zone_id
+  name    = local.domain
+  type    = "A"
+
+  alias {
+    name                   = aws_cloudfront_distribution.this.domain_name
+    zone_id                = aws_cloudfront_distribution.this.hosted_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "apex_ipv6" {
+  zone_id = data.aws_route53_zone.zone.zone_id
+  name    = local.domain
+  type    = "AAAA"
+
+  alias {
+    name                   = aws_cloudfront_distribution.this.domain_name
+    zone_id                = aws_cloudfront_distribution.this.hosted_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "www_ipv4" {
+  zone_id = data.aws_route53_zone.zone.zone_id
+  name    = "www"
+  type    = "A"
+
+  alias {
+    name                   = aws_cloudfront_distribution.this.domain_name
+    zone_id                = aws_cloudfront_distribution.this.hosted_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "www_ipv6" {
+  zone_id = data.aws_route53_zone.zone.zone_id
+  name    = "www"
+  type    = "AAAA"
+
+  alias {
+    name                   = aws_cloudfront_distribution.this.domain_name
+    zone_id                = aws_cloudfront_distribution.this.hosted_zone_id
+    evaluate_target_health = false
+  }
+}
+
+# The below lints are disabled for cost reasons and because the site deployed
+# behind this cloudfront distribution is empty.
+#
+# tfsec:ignore:aws-cloudfront-enable-waf
+# tfsec:ignore:aws-cloudfront-enable-logging
+resource "aws_cloudfront_distribution" "this" {
+  comment = "domain redirect ${local.domain} to ${var.redirect_to}"
+
+  enabled             = true
+  wait_for_deployment = false
+  is_ipv6_enabled     = true
+  http_version        = "http2and3"
+  price_class         = "PriceClass_All"
+
+  aliases = [local.domain, "www.${local.domain}"]
+
+  viewer_certificate {
+    acm_certificate_arn = aws_acm_certificate.this.arn
+    ssl_support_method  = "sni-only"
+    # https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/secure-connections-supported-viewer-protocols-ciphers.html
+    minimum_protocol_version = "TLSv1.2_2021"
+  }
+
+  default_cache_behavior {
+    target_origin_id       = "main"
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+    compress               = true
+    viewer_protocol_policy = "redirect-to-https"
+
+    forwarded_values {
+      headers      = []
+      query_string = false
+      cookies {
+        forward = "none"
+      }
+    }
+
+    min_ttl     = 0
+    default_ttl = 30
+    max_ttl     = 86400
+
+    response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+
+    function_association {
+      event_type   = "viewer-request"
+      function_arn = aws_cloudfront_function.request_handler.arn
+    }
+  }
+
+  origin {
+    domain_name = "example.com" # dummy, the function always returns a redirect
+    origin_id   = "main"
+
+    custom_origin_config {
+      http_port              = 80
+      https_port             = 443
+      origin_protocol_policy = "https-only"
+      origin_ssl_protocols   = ["TLSv1.2"]
+    }
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+}
+
+resource "aws_cloudfront_function" "request_handler" {
+  name    = "cloudfront-${replace(local.domain, ".", "-")}-request-handler"
+  runtime = "cloudfront-js-1.0"
+  comment = "redirect request handler from ${local.domain} to ${var.redirect_to}"
+  publish = true
+  code    = templatefile("${path.module}/request-handler.js", { redirect_to = var.redirect_to })
+}
+
+resource "aws_cloudfront_response_headers_policy" "this" {
+  name    = "cloudfront-${replace(local.domain, ".", "-")}-response-headers"
+  comment = "redirect domain from ${local.domain} to ${var.redirect_to}"
+
+  security_headers_config {
+    # https://infosec.mozilla.org/guidelines/web_security#content-security-policy
+    # https://infosec.mozilla.org/guidelines/web_security#x-frame-options
+    content_security_policy {
+      content_security_policy = "frame-ancestors 'none'; style-src 'self'; img-src 'self'; object-src 'none'; script-src 'none'; trusted-types; require-trusted-types-for 'script';"
+      override                = true
+    }
+
+    # https://infosec.mozilla.org/guidelines/web_security#x-content-type-options
+    content_type_options {
+      override = true
+    }
+
+    # https://infosec.mozilla.org/guidelines/web_security#x-frame-options
+    frame_options {
+      frame_option = "DENY"
+      override     = true
+    }
+
+    # https://infosec.mozilla.org/guidelines/web_security#referrer-policy
+    referrer_policy {
+      referrer_policy = "no-referrer"
+      override        = true
+    }
+
+    # https://infosec.mozilla.org/guidelines/web_security#http-strict-transport-security
+    strict_transport_security {
+      access_control_max_age_sec = 63072000
+      include_subdomains         = false
+      preload                    = false
+      override                   = true
+    }
+
+    # https://infosec.mozilla.org/guidelines/web_security#x-xss-protection
+    xss_protection {
+      protection = true
+      mode_block = true
+      override   = true
+    }
+  }
+}

--- a/modules/domain-redirect/outputs.tf
+++ b/modules/domain-redirect/outputs.tf
@@ -1,0 +1,9 @@
+output "cert_arn" {
+  description = "The ARN of the created ACM certificate"
+  value       = aws_acm_certificate.this.arn
+}
+
+output "cloudfront_domain_name" {
+  description = "The domain name corresponding to the CloudFront distribution"
+  value       = aws_cloudfront_distribution.this.domain_name
+}

--- a/modules/domain-redirect/outputs.tf
+++ b/modules/domain-redirect/outputs.tf
@@ -1,6 +1,6 @@
 output "cert_arn" {
   description = "The ARN of the created ACM certificate"
-  value       = aws_acm_certificate.this.arn
+  value       = module.cert.cert_arn
 }
 
 output "cloudfront_domain_name" {

--- a/modules/domain-redirect/request-handler.js
+++ b/modules/domain-redirect/request-handler.js
@@ -1,0 +1,13 @@
+function handler(event) {
+  var request = event.request;
+  var uri = request.uri;
+
+  var redirectTo = "${redirect_to}" + uri;
+  var response = {
+    statusCode: 302,
+    statusDescription: "Found",
+    headers: { location: { value: redirectTo } },
+  };
+
+  return response;
+}

--- a/modules/domain-redirect/variables.tf
+++ b/modules/domain-redirect/variables.tf
@@ -1,0 +1,23 @@
+variable "zone_id" {
+  description = "The id of the Route53 zone to create redirect records in"
+  type        = string
+}
+
+variable "redirect_to" {
+  description = "The website to redirect to"
+
+  validation {
+    condition     = length(var.redirect_to) > length("https://x.x")
+    error_message = "Redirect target must be properly formatted."
+  }
+
+  validation {
+    condition     = startswith(var.redirect_to, "https://")
+    error_message = "Redirect target must be an HTTPs URL."
+  }
+
+  validation {
+    condition     = !endswith(var.redirect_to, "/")
+    error_message = "Redirect target must be a URL that does not end in `/`."
+  }
+}

--- a/modules/domain-redirect/variables.tf
+++ b/modules/domain-redirect/variables.tf
@@ -1,3 +1,8 @@
+variable "access_logs_bucket" {
+  description = "The name of the bucket to use as the destination for access logs"
+  type        = string
+}
+
 variable "zone_id" {
   description = "The id of the Route53 zone to create redirect records in"
   type        = string

--- a/modules/domain-redirect/versions.tf
+++ b/modules/domain-redirect/versions.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    aws = {
+      source                = "hashicorp/aws"
+      version               = "~> 4.27"
+      configuration_aliases = [aws.us_east_1]
+    }
+  }
+
+  required_version = "~> 1.0"
+}

--- a/modules/github-domain-verification/README.md
+++ b/modules/github-domain-verification/README.md
@@ -1,0 +1,28 @@
+# GitHub Domain Verification
+
+This folder contains a Terraform module to provision a TXT record that verifies
+ownership of a domain for a GitHub organization.
+
+## Usage
+
+```terraform
+module "github_challenge" {
+  source = "../modules/github-domain-verification"
+
+  zone_id             = aws_route53_zone.this.zone_id
+  github_organization = "artichoke"
+  domain              = "artichokeruby.org"
+  challenge           = "xxxxx"
+}
+```
+
+## Parameters
+
+- `zone_id`: The id of the Route53 zone to create DKIM records in.
+- `github_organization`: The GitHub organization slug, e.g. `artichoke`.
+- `domain`: The domain to verify.
+- `challenge`: Challenge token.
+
+## Outputs
+
+This module has no outputs.

--- a/modules/github-domain-verification/README.md
+++ b/modules/github-domain-verification/README.md
@@ -18,7 +18,7 @@ module "github_challenge" {
 
 ## Parameters
 
-- `zone_id`: The id of the Route53 zone to create DKIM records in.
+- `zone_id`: The id of the Route53 zone to create TXT records in.
 - `github_organization`: The GitHub organization slug, e.g. `artichoke`.
 - `domain`: The domain to verify.
 - `challenge`: Challenge token.

--- a/modules/github-domain-verification/main.tf
+++ b/modules/github-domain-verification/main.tf
@@ -1,0 +1,16 @@
+data "aws_route53_zone" "zone" {
+  zone_id = var.zone_id
+}
+
+resource "aws_route53_record" "this" {
+  zone_id = data.aws_route53_zone.zone.zone_id
+  name    = "_github-challenge-${var.github_organization}.${var.domain}"
+  type    = "TXT"
+  ttl     = "3600"
+
+  records = [var.challenge]
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}

--- a/modules/github-domain-verification/variables.tf
+++ b/modules/github-domain-verification/variables.tf
@@ -1,5 +1,5 @@
 variable "zone_id" {
-  description = "The id of the Route53 zone to create DKIM records in"
+  description = "The id of the Route53 zone to create TXT records in"
   type        = string
 }
 

--- a/modules/github-domain-verification/variables.tf
+++ b/modules/github-domain-verification/variables.tf
@@ -1,0 +1,34 @@
+variable "zone_id" {
+  description = "The id of the Route53 zone to create DKIM records in"
+  type        = string
+}
+
+variable "github_organization" {
+  description = "The GitHub organization slug"
+  type        = string
+
+  validation {
+    condition     = length(var.github_organization) > 0
+    error_message = "GitHub organization must not be empty."
+  }
+}
+
+variable "domain" {
+  description = "The domain to verify"
+  type        = string
+
+  validation {
+    condition     = length(var.domain) > 0
+    error_message = "Domain must not be empty."
+  }
+}
+
+variable "challenge" {
+  description = "The challenge token"
+  type        = string
+
+  validation {
+    condition     = length(var.challenge) > 0 && length(var.challenge) < 255
+    error_message = "Challenge token must not be empty and be shorter than 255 characters."
+  }
+}

--- a/modules/github-domain-verification/versions.tf
+++ b/modules/github-domain-verification/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+
+  required_version = "~> 1.0"
+}

--- a/modules/github-pages-domain-dns/README.md
+++ b/modules/github-pages-domain-dns/README.md
@@ -17,7 +17,7 @@ module "artichokeruby_org_github_pages" {
 
 ## Parameters
 
-- `zone_id`: The id of the Route53 zone to create DKIM records in.
+- `zone_id`: The id of the Route53 zone to create TXT records in.
 - `github_organization`: The GitHub organization slug, e.g. `artichoke`.
 
 ## Outputs

--- a/modules/github-pages-domain-dns/README.md
+++ b/modules/github-pages-domain-dns/README.md
@@ -1,0 +1,25 @@
+# GitHub Pages Domain DNS
+
+This folder contains a Terraform module to provision DNS records in an AWS
+Route53 zone to setup GitHub pages for the `www` and apex domains in the given
+zone.
+
+## Usage
+
+```terraform
+module "artichokeruby_org_github_pages" {
+  source = "../modules/github-pages-domain-dns"
+
+  zone_id             = aws_route53_zone.this.zone_id
+  github_organization = "artichoke"
+}
+```
+
+## Parameters
+
+- `zone_id`: The id of the Route53 zone to create DKIM records in.
+- `github_organization`: The GitHub organization slug, e.g. `artichoke`.
+
+## Outputs
+
+This module has no outputs.

--- a/modules/github-pages-domain-dns/main.tf
+++ b/modules/github-pages-domain-dns/main.tf
@@ -1,0 +1,59 @@
+data "aws_route53_zone" "zone" {
+  zone_id = var.zone_id
+}
+
+# The given site is hosted on GitHub Pages at apex and www.
+#
+# Set up DNS to point to GitHub Pages and handle the redirect from the apex
+# domain to `www`.
+#
+# https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site
+
+resource "aws_route53_record" "apex_ipv4" {
+  zone_id = aws_route53_zone.this.zone_id
+  name    = aws_route53_zone.this.name
+  type    = "A"
+  ttl     = "300"
+
+  records = [
+    "185.199.108.153",
+    "185.199.109.153",
+    "185.199.110.153",
+    "185.199.111.153",
+  ]
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_route53_record" "apex_ipv6" {
+  zone_id = aws_route53_zone.this.zone_id
+  name    = aws_route53_zone.this.name
+  type    = "AAAA"
+  ttl     = "300"
+
+  records = [
+    "2606:50c0:8000::153",
+    "2606:50c0:8001::153",
+    "2606:50c0:8002::153",
+    "2606:50c0:8003::153",
+  ]
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_route53_record" "www_cname" {
+  zone_id = aws_route53_zone.this.zone_id
+  name    = "www"
+  type    = "CNAME"
+  ttl     = "300"
+
+  records = ["${var.github_organization}.github.io"]
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}

--- a/modules/github-pages-domain-dns/variables.tf
+++ b/modules/github-pages-domain-dns/variables.tf
@@ -1,0 +1,14 @@
+variable "zone_id" {
+  description = "The id of the Route53 zone to create GitHub Pages records in"
+  type        = string
+}
+
+variable "github_organization" {
+  description = "The GitHub organization slug"
+  type        = string
+
+  validation {
+    condition     = length(var.github_organization) > 0
+    error_message = "GitHub organization must not be empty."
+  }
+}

--- a/modules/github-pages-domain-dns/versions.tf
+++ b/modules/github-pages-domain-dns/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+
+  required_version = "~> 1.0"
+}

--- a/modules/github-pages-domain-verification/README.md
+++ b/modules/github-pages-domain-verification/README.md
@@ -18,7 +18,7 @@ module "github_challenge" {
 
 ## Parameters
 
-- `zone_id`: The id of the Route53 zone to create DKIM records in.
+- `zone_id`: The id of the Route53 zone to create TXT records in.
 - `github_organization`: The GitHub organization slug, e.g. `artichoke`.
 - `domain`: The domain to verify.
 - `challenge`: Challenge token.

--- a/modules/github-pages-domain-verification/README.md
+++ b/modules/github-pages-domain-verification/README.md
@@ -1,0 +1,28 @@
+# GitHub Pages Domain Verification
+
+This folder contains a Terraform module to provision a TXT record that verifies
+an organization's ownership of a domain for a GitHub Pages.
+
+## Usage
+
+```terraform
+module "github_challenge" {
+  source = "../modules/github-pages-domain-verification"
+
+  zone_id             = aws_route53_zone.this.zone_id
+  github_organization = "artichoke"
+  domain              = "artichokeruby.org"
+  challenge           = "xxxxx"
+}
+```
+
+## Parameters
+
+- `zone_id`: The id of the Route53 zone to create DKIM records in.
+- `github_organization`: The GitHub organization slug, e.g. `artichoke`.
+- `domain`: The domain to verify.
+- `challenge`: Challenge token.
+
+## Outputs
+
+This module has no outputs.

--- a/modules/github-pages-domain-verification/main.tf
+++ b/modules/github-pages-domain-verification/main.tf
@@ -1,0 +1,16 @@
+data "aws_route53_zone" "zone" {
+  zone_id = var.zone_id
+}
+
+resource "aws_route53_record" "this" {
+  zone_id = data.aws_route53_zone.zone.zone_id
+  name    = "_github-pages-challenge-${var.github_organization}.${var.domain}"
+  type    = "TXT"
+  ttl     = "3600"
+
+  records = [var.challenge]
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}

--- a/modules/github-pages-domain-verification/variables.tf
+++ b/modules/github-pages-domain-verification/variables.tf
@@ -1,5 +1,5 @@
 variable "zone_id" {
-  description = "The id of the Route53 zone to create DKIM records in"
+  description = "The id of the Route53 zone to create TXT records in"
   type        = string
 }
 

--- a/modules/github-pages-domain-verification/variables.tf
+++ b/modules/github-pages-domain-verification/variables.tf
@@ -1,0 +1,34 @@
+variable "zone_id" {
+  description = "The id of the Route53 zone to create DKIM records in"
+  type        = string
+}
+
+variable "github_organization" {
+  description = "The GitHub organization slug"
+  type        = string
+
+  validation {
+    condition     = length(var.github_organization) > 0
+    error_message = "GitHub organization must not be empty."
+  }
+}
+
+variable "domain" {
+  description = "The domain to verify"
+  type        = string
+
+  validation {
+    condition     = length(var.domain) > 0
+    error_message = "Domain must not be empty."
+  }
+}
+
+variable "challenge" {
+  description = "The challenge token"
+  type        = string
+
+  validation {
+    condition     = length(var.challenge) > 0 && length(var.challenge) < 255
+    error_message = "Challenge token must not be empty and be shorter than 255 characters."
+  }
+}

--- a/modules/github-pages-domain-verification/versions.tf
+++ b/modules/github-pages-domain-verification/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+
+  required_version = "~> 1.0"
+}

--- a/modules/github-pages-subdomain-dns/README.md
+++ b/modules/github-pages-subdomain-dns/README.md
@@ -1,0 +1,26 @@
+# GitHub Pages Subdomain DNS
+
+This folder contains a Terraform module to provision DNS records in an AWS
+Route53 zone to setup GitHub pages for the given subdomain.
+
+## Usage
+
+```terraform
+module "codecov_artichokeruby_org_github_pages" {
+  source = "../modules/github-pages-domain-dns"
+
+  zone_id             = aws_route53_zone.this.zone_id
+  subdomain           = "codecov"
+  github_organization = "artichoke"
+}
+```
+
+## Parameters
+
+- `zone_id`: The id of the Route53 zone to create DKIM records in.
+- `subdomain`: The subdomain to setup GitHub Pages on.
+- `github_organization`: The GitHub organization slug, e.g. `artichoke`.
+
+## Outputs
+
+This module has no outputs.

--- a/modules/github-pages-subdomain-dns/README.md
+++ b/modules/github-pages-subdomain-dns/README.md
@@ -17,7 +17,7 @@ module "codecov_artichokeruby_org_github_pages" {
 
 ## Parameters
 
-- `zone_id`: The id of the Route53 zone to create DKIM records in.
+- `zone_id`: The id of the Route53 zone to create TXT records in.
 - `subdomain`: The subdomain to setup GitHub Pages on.
 - `github_organization`: The GitHub organization slug, e.g. `artichoke`.
 

--- a/modules/github-pages-subdomain-dns/main.tf
+++ b/modules/github-pages-subdomain-dns/main.tf
@@ -1,0 +1,18 @@
+data "aws_route53_zone" "zone" {
+  zone_id = var.zone_id
+}
+
+# https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site
+
+resource "aws_route53_record" "www_cname" {
+  zone_id = aws_route53_zone.this.zone_id
+  name    = var.subdomain
+  type    = "CNAME"
+  ttl     = "300"
+
+  records = ["${var.github_organization}.github.io"]
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}

--- a/modules/github-pages-subdomain-dns/variables.tf
+++ b/modules/github-pages-subdomain-dns/variables.tf
@@ -1,0 +1,24 @@
+variable "zone_id" {
+  description = "The id of the Route53 zone to create GitHub Pages records in"
+  type        = string
+}
+
+variable "subdomain" {
+  description = "The subdomain to setup GitHub Pages for"
+  type        = string
+
+  validation {
+    condition     = length(var.subdomain) > 0
+    error_message = "Subdomain must not be empty."
+  }
+}
+
+variable "github_organization" {
+  description = "The GitHub organization slug"
+  type        = string
+
+  validation {
+    condition     = length(var.github_organization) > 0
+    error_message = "GitHub organization must not be empty."
+  }
+}

--- a/modules/github-pages-subdomain-dns/versions.tf
+++ b/modules/github-pages-subdomain-dns/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+
+  required_version = "~> 1.0"
+}

--- a/modules/google-site-verification/README.md
+++ b/modules/google-site-verification/README.md
@@ -1,0 +1,34 @@
+# Google Site Verification
+
+This folder contains a Terraform module to provision DNS records in an AWS
+Route53 zone to verify a domain to a Google Service, for example Google Search
+Console.
+
+If setting verification keys for a Google Workspace property, see the
+[`google-workspace`] module.
+
+[`google-workspace`]: ../google-workspace
+
+## Usage
+
+```terraform
+module "google_workspace" {
+  source = "../modules/google-site-verification"
+
+  zone_id = aws_route53_zone.this.zone_id
+
+  site_verification_keys = [
+    "abc...",
+    "xyz...",
+  ]
+}
+```
+
+## Parameters
+
+- `zone_id`: The id of the Route53 zone to create DNS records in.
+- `site_verification_keys`: Google site verification keys for the apex domain.
+
+## Outputs
+
+This module has no outputs.

--- a/modules/google-site-verification/main.tf
+++ b/modules/google-site-verification/main.tf
@@ -1,0 +1,16 @@
+data "aws_route53_zone" "zone" {
+  zone_id = var.zone_id
+}
+
+resource "aws_route53_record" "txt" {
+  zone_id = data.aws_route53_zone.zone.zone_id
+  name    = data.aws_route53_zone.zone.name
+  type    = "TXT"
+  ttl     = "300"
+
+  records = formatlist("google-site-verification=%s", var.site_verification_keys)
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}

--- a/modules/google-site-verification/variables.tf
+++ b/modules/google-site-verification/variables.tf
@@ -1,0 +1,14 @@
+variable "zone_id" {
+  description = "The id of the Route53 zone to create DNS records in"
+  type        = string
+}
+
+variable "site_verification_keys" {
+  description = "Google site verification keys"
+  type        = list(string)
+
+  validation {
+    condition     = length(var.site_verification_keys) > 0
+    error_message = "Must provide at least one site verification key."
+  }
+}

--- a/modules/google-site-verification/versions.tf
+++ b/modules/google-site-verification/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+
+  required_version = "~> 1.0"
+}

--- a/modules/google-workspace-dkim/README.md
+++ b/modules/google-workspace-dkim/README.md
@@ -1,7 +1,7 @@
 # Google Workspace DKIM TXT Record
 
-This folder contains a Terraform module to provision an DKIM TXT record in an
-AWS Route53 zone.
+This folder contains a Terraform module to provision an Google Workspace DKIM
+TXT record in an AWS Route53 zone.
 
 ## Usage
 

--- a/modules/google-workspace-dkim/README.md
+++ b/modules/google-workspace-dkim/README.md
@@ -1,0 +1,24 @@
+# Google Workspace DKIM TXT Record
+
+This folder contains a Terraform module to provision an DKIM TXT record in an
+AWS Route53 zone.
+
+## Usage
+
+```terraform
+module "dkim" {
+  source = "../modules/google-workspace-dkim"
+
+  zone_id     = aws_route53_zone.this.zone_id
+  dkim_record = "v=DKIM1; k=rsa; p=..."
+}
+```
+
+## Parameters
+
+- `zone_id`: The id of the Route53 zone to create DKIM records in.
+- `dkim_record`: The full value of the DKIM TXT record.
+
+## Outputs
+
+This module has no outputs.

--- a/modules/google-workspace-dkim/main.tf
+++ b/modules/google-workspace-dkim/main.tf
@@ -1,0 +1,19 @@
+resource "aws_route53_record" "this" {
+  zone_id = var.zone_id
+  name    = "google._domainkey"
+  type    = "TXT"
+  ttl     = "3600"
+
+  # Per terraform docs[^1]:
+  #
+  # > To specify a single record value longer than 255 characters such as a TXT
+  # record for DKIM, add \"\" inside the Terraform configuration string (e.g.,
+  # `"first255characters\"\"morecharacters"`).
+  #
+  # [^1]: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record
+  records = [replace(var.dkim_record, "/(.{254})/", "$1\" \"")]
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}

--- a/modules/google-workspace-dkim/main.tf
+++ b/modules/google-workspace-dkim/main.tf
@@ -1,5 +1,9 @@
-resource "aws_route53_record" "this" {
+data "aws_route53_zone" "zone" {
   zone_id = var.zone_id
+}
+
+resource "aws_route53_record" "this" {
+  zone_id = data.aws_route53_zone.zone.zone_id
   name    = "google._domainkey"
   type    = "TXT"
   ttl     = "3600"

--- a/modules/google-workspace-dkim/variables.tf
+++ b/modules/google-workspace-dkim/variables.tf
@@ -1,0 +1,14 @@
+variable "zone_id" {
+  description = "The id of the Route53 zone to create DKIM records in"
+  type        = string
+}
+
+variable "dkim_record" {
+  description = "The DKIM TXT record value"
+  type        = string
+
+  validation {
+    condition     = substr(var.dkim_record, 0, length("v=DKIM1; k=rsa; p=")) == "v=DKIM1; k=rsa; p="
+    error_message = "Include the full DKIM TXT record including 'v=DKIM1; k=rsa; p='."
+  }
+}

--- a/modules/google-workspace-dkim/versions.tf
+++ b/modules/google-workspace-dkim/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+
+  required_version = "~> 1.0"
+}

--- a/modules/google-workspace-mx/README.md
+++ b/modules/google-workspace-mx/README.md
@@ -29,7 +29,7 @@ module "mx" {
 
 ## Parameters
 
-- `zone_id`: The id of the Route53 zone to create DKIM records in.
+- `zone_id`: The id of the Route53 zone to create MX records in.
 
 ## Outputs
 

--- a/modules/google-workspace-mx/README.md
+++ b/modules/google-workspace-mx/README.md
@@ -1,0 +1,22 @@
+# Google Workspace MX Records
+
+This folder contains a Terraform module to provision MX records for a Google
+Workspace domain in an AWS Route53 zone.
+
+## Usage
+
+```terraform
+module "mx" {
+  source = "../modules/google-workspace-mx"
+
+  zone_id = aws_route53_zone.this.zone_id
+}
+```
+
+## Parameters
+
+- `zone_id`: The id of the Route53 zone to create DKIM records in.
+
+## Outputs
+
+This module has no outputs.

--- a/modules/google-workspace-mx/README.md
+++ b/modules/google-workspace-mx/README.md
@@ -3,6 +3,20 @@
 This folder contains a Terraform module to provision MX records for a Google
 Workspace domain in an AWS Route53 zone.
 
+This module uses the "I signed up before 2023" configuration from the [Google
+Workspace MX record values][workspace-mx] documentation, which provisions these
+MX records:
+
+| Name/Host/Alias | Priority | Value/Answer/Destination |
+| --------------- | -------- | ------------------------ |
+| Blank or @      | 1        | ASPMX.L.GOOGLE.COM       |
+| Blank or @      | 5        | ALT1.ASPMX.L.GOOGLE.COM  |
+| Blank or @      | 5        | ALT2.ASPMX.L.GOOGLE.COM  |
+| Blank or @      | 10       | ALT3.ASPMX.L.GOOGLE.COM  |
+| Blank or @      | 10       | ALT4.ASPMX.L.GOOGLE.COM  |
+
+[workspace-mx]: https://support.google.com/a/answer/174125?hl=en&fl=1
+
 ## Usage
 
 ```terraform

--- a/modules/google-workspace-mx/main.tf
+++ b/modules/google-workspace-mx/main.tf
@@ -1,0 +1,25 @@
+data "aws_route53_zone" "zone" {
+  zone_id = var.zone_id
+}
+
+# G Suite MX record values: https://support.google.com/a/answer/174125?hl=en
+
+resource "aws_route53_record" "this" {
+  zone_id = var.zone_id
+  name    = data.aws_route53_zone.zone.name
+  type    = "MX"
+  ttl     = "3600"
+
+  records = [
+    "1 ASPMX.L.GOOGLE.COM.",
+    "5 ALT1.ASPMX.L.GOOGLE.COM.",
+    "5 ALT2.ASPMX.L.GOOGLE.COM.",
+    "10 ALT3.ASPMX.L.GOOGLE.COM.",
+    "10 ALT4.ASPMX.L.GOOGLE.COM.",
+  ]
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+

--- a/modules/google-workspace-mx/main.tf
+++ b/modules/google-workspace-mx/main.tf
@@ -3,9 +3,11 @@ data "aws_route53_zone" "zone" {
 }
 
 # G Suite MX record values: https://support.google.com/a/answer/174125?hl=en
+#
+# Use "I signed up before 2023" configuration.
 
 resource "aws_route53_record" "this" {
-  zone_id = var.zone_id
+  zone_id = data.aws_route53_zone.zone.zone_id
   name    = data.aws_route53_zone.zone.name
   type    = "MX"
   ttl     = "3600"

--- a/modules/google-workspace-mx/variables.tf
+++ b/modules/google-workspace-mx/variables.tf
@@ -1,4 +1,4 @@
 variable "zone_id" {
-  description = "The id of the Route53 zone to create DKIM records in"
+  description = "The id of the Route53 zone to create MX records in"
   type        = string
 }

--- a/modules/google-workspace-mx/variables.tf
+++ b/modules/google-workspace-mx/variables.tf
@@ -1,0 +1,4 @@
+variable "zone_id" {
+  description = "The id of the Route53 zone to create DKIM records in"
+  type        = string
+}

--- a/modules/google-workspace-mx/versions.tf
+++ b/modules/google-workspace-mx/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+
+  required_version = "~> 1.0"
+}

--- a/modules/google-workspace/README.md
+++ b/modules/google-workspace/README.md
@@ -21,7 +21,7 @@ module "google_workspace" {
 
 ## Parameters
 
-- `zone_id`: The id of the Route53 zone to create DKIM records in.
+- `zone_id`: The id of the Route53 zone to create DNS records in.
 - `dkim_record`: The full value of the DKIM TXT record.
 - `site_verification_keys`: Google site verification keys for the apex domain.
 

--- a/modules/google-workspace/README.md
+++ b/modules/google-workspace/README.md
@@ -1,0 +1,30 @@
+# Google Workspace
+
+This folder contains a Terraform module to provision DNS records in an AWS
+Route53 zone to setup email for a Google Workspace domain.
+
+## Usage
+
+```terraform
+module "google_workspace" {
+  source = "../modules/google-workspace"
+
+  zone_id     = aws_route53_zone.this.zone_id
+  dkim_record = "v=DKIM1; k=rsa; p=..."
+
+  site_verification_keys = [
+    "abc...",
+    "xyz...",
+  ]
+}
+```
+
+## Parameters
+
+- `zone_id`: The id of the Route53 zone to create DKIM records in.
+- `dkim_record`: The full value of the DKIM TXT record.
+- `site_verification_keys`: Google site verification keys for the apex domain.
+
+## Outputs
+
+This module has no outputs.

--- a/modules/google-workspace/main.tf
+++ b/modules/google-workspace/main.tf
@@ -1,0 +1,32 @@
+data "aws_route53_zone" "zone" {
+  zone_id = var.zone_id
+}
+
+module "mx" {
+  source = "../google-workspace-mx"
+
+  zone_id = var.zone_id
+}
+
+module "dkim" {
+  source = "../google-workspace-dkim"
+
+  zone_id     = var.zone_id
+  dkim_record = var.dkim_record
+}
+
+resource "aws_route53_record" "txt" {
+  zone_id = var.zone_id
+  name    = data.aws_route53_zone.zone.name
+  type    = "TXT"
+  ttl     = "300"
+
+  records = flatten([
+    "v=spf1 include:_spf.google.com ~all",
+    formatlist("google-site-verification=%s", var.site_verification_keys),
+  ])
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}

--- a/modules/google-workspace/main.tf
+++ b/modules/google-workspace/main.tf
@@ -5,18 +5,18 @@ data "aws_route53_zone" "zone" {
 module "mx" {
   source = "../google-workspace-mx"
 
-  zone_id = var.zone_id
+  zone_id = data.aws_route53_zone.zone.zone_id
 }
 
 module "dkim" {
   source = "../google-workspace-dkim"
 
-  zone_id     = var.zone_id
+  zone_id     = data.aws_route53_zone.zone.zone_id
   dkim_record = var.dkim_record
 }
 
 resource "aws_route53_record" "txt" {
-  zone_id = var.zone_id
+  zone_id = data.aws_route53_zone.zone.zone_id
   name    = data.aws_route53_zone.zone.name
   type    = "TXT"
   ttl     = "300"

--- a/modules/google-workspace/variables.tf
+++ b/modules/google-workspace/variables.tf
@@ -1,0 +1,19 @@
+variable "zone_id" {
+  description = "The id of the Route53 zone to create DKIM records in"
+  type        = string
+}
+
+variable "dkim_record" {
+  description = "The DKIM TXT record value"
+  type        = string
+
+  validation {
+    condition     = substr(var.dkim_record, 0, length("v=DKIM1; k=rsa; p=")) == "v=DKIM1; k=rsa; p="
+    error_message = "Include the full DKIM TXT record including 'v=DKIM1; k=rsa; p='."
+  }
+}
+
+variable "site_verification_keys" {
+  description = "Google site verification keys"
+  type        = list(string)
+}

--- a/modules/google-workspace/variables.tf
+++ b/modules/google-workspace/variables.tf
@@ -1,5 +1,5 @@
 variable "zone_id" {
-  description = "The id of the Route53 zone to create DKIM records in"
+  description = "The id of the Route53 zone to create DNS records in"
   type        = string
 }
 

--- a/modules/google-workspace/versions.tf
+++ b/modules/google-workspace/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+
+  required_version = "~> 1.0"
+}


### PR DESCRIPTION
Unblock https://github.com/artichoke/project-infrastructure/issues/519.

Status: changes are applied in terraform up to b7813d4e4b2644ddf2b22766dd26dbba5b180086.

Done so far:

- Add CloudFront terraform module to replace the Google Domains-provided website forwarding.
- Add terraform modules for GitHub organization domain and pages domain DNS verification.
- Add Google Workspace modules (required for artichokeruby.org mailboxes).
- Purge a lot of unnecessary terraform source files.
- Setup DNS for artichokeruby.net, artichokeruby.com, artichokeruby.run.
- Install CloudFront domain redirects for artichokeruby.net, artichokeruby.com, artichokeruby.run.
- Cut over name servers for artichokeruby.net, artichokeruby.com, artichokeruby.run in Google Domains.
- Ensure domains remain verified in GitHub.