### PR TITLE
Add additional GitHub Actions OIDC thumbprint

### DIFF
--- a/modules/github-actions-oidc-provider/main.tf
+++ b/modules/github-actions-oidc-provider/main.tf
@@ -9,6 +9,14 @@ resource "aws_iam_openid_connect_provider" "github" {
     "sts.amazonaws.com"
   ]
 
+  # Thumbprint documentation:
+  #
   # https://github.blog/changelog/2022-01-13-github-actions-update-on-oidc-based-deployments-to-aws/
-  thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1"]
+  # https://github.blog/changelog/2023-06-27-github-actions-update-on-oidc-integration-with-aws/
+  # https://github.com/artichoke/project-infrastructure/issues/533
+  # https://github.com/aws-actions/configure-aws-credentials/blob/0270d0bcecaf2c76c8fbf7bf3de0d65a6d06e076/README.md#recent-updates
+  thumbprint_list = [
+    "6938fd4d98bab03faadb97b34396831e3780aea1",
+    "1c58a3a8518e8759bf075b76b750d4f2df264fcd",
+  ]
 }


### PR DESCRIPTION
These changes are applied:

```
Terraform will perform the following actions:

  # module.github_actions_oidc_provider.aws_iam_openid_connect_provider.github will be updated in-place
  ~ resource "aws_iam_openid_connect_provider" "github" {
        id              = "arn:aws:iam::447522982029:oidc-provider/token.actions.githubusercontent.com"
        tags            = {}
      ~ thumbprint_list = [
            "6938fd4d98bab03faadb97b34396831e3780aea1",
          + "1c58a3a8518e8759bf075b76b750d4f2df264fcd",
        ]
        # (4 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

See: https://github.blog/changelog/2023-06-27-github-actions-update-on-oidc-integration-with-aws/
Fixes https://github.com/artichoke/project-infrastructure/issues/533