### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      gha-deps:
+        patterns:
+          - "*"
     assignees:
       - lopopolo
     labels:
@@ -13,7 +17,10 @@ updates:
     directory: "/"
     schedule:
       interval: monthly
-    open-pull-requests-limit: 10
+    groups:
+      bundler-deps:
+        patterns:
+          - "*"
     assignees:
       - lopopolo
     labels:
@@ -22,7 +29,10 @@ updates:
     directory: "/aws"
     schedule:
       interval: monthly
-    open-pull-requests-limit: 10
+    groups:
+      tf-deps-aws:
+        patterns:
+          - "*"
     assignees:
       - lopopolo
     labels:
@@ -32,7 +42,10 @@ updates:
     directory: "/github-org-artichoke"
     schedule:
       interval: monthly
-    open-pull-requests-limit: 10
+    groups:
+      tf-deps-gh-artichoke:
+        patterns:
+          - "*"
     assignees:
       - lopopolo
     labels:
@@ -42,7 +55,10 @@ updates:
     directory: "/github-org-artichokeruby"
     schedule:
       interval: monthly
-    open-pull-requests-limit: 10
+    groups:
+      tf-deps-gh-artichokeruby:
+        patterns:
+          - "*"
     assignees:
       - lopopolo
     labels:
@@ -52,7 +68,10 @@ updates:
     directory: "/github-org-artichoke-ruby"
     schedule:
       interval: monthly
-    open-pull-requests-limit: 10
+    groups:
+      tf-deps-gh-artichoke-ruby:
+        patterns:
+          - "*"
     assignees:
       - lopopolo
     labels:
@@ -62,7 +81,10 @@ updates:
     directory: "/remote-state"
     schedule:
       interval: monthly
-    open-pull-requests-limit: 10
+    groups:
+      tf-deps-remote-state:
+        patterns:
+          - "*"
     assignees:
       - lopopolo
     labels:


### PR DESCRIPTION
Bundle dep upgrades into a rollup PR using dependabot groups.

Works around this warning that appears on some Artichoke repositories:

> **Dependabot updates are paused**
>
> We noticed you haven't used Dependabot in a while, so we've paused new pull
> requests for you. Merge a Dependabot pull request to resume automatically
> creating Dependabot updates or disable security and version updates. See open
> Dependabot pull requests


See:

- https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/
- https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups