### PR TITLE
Setup `artichoke.run` DNS on Route 53

### DIFF
--- a/aws/dns_artichoke.run.tf
+++ b/aws/dns_artichoke.run.tf
@@ -1,0 +1,55 @@
+locals {
+  artichoke_run_github_challenges = [
+    { org = "artichoke", domain = "artichoke.run", challenge = "269dfad3e5" },
+    { org = "artichoke", domain = "rubyconf2019.artichoke.run", challenge = "7334204bc9" },
+    { org = "artichoke", domain = "www.artichoke.run", challenge = "cb003a6b0b" },
+    { org = "artichokeruby", domain = "artichoke.run", challenge = "62c47d9852" },
+    { org = "artichokeruby", domain = "rubyconf2019.artichoke.run", challenge = "45a5783abe" },
+    { org = "artichokeruby", domain = "www.artichoke.run", challenge = "58c732d6b6" },
+    { org = "artichoke-ruby-org", domain = "artichoke.run", challenge = "636dd41740" },
+    { org = "artichoke-ruby-org", domain = "rubyconf2019.artichoke.run", challenge = "a5e31fdb89" },
+    { org = "artichoke-ruby-org", domain = "www.artichoke.run", challenge = "0b0528b66d" },
+  ]
+}
+
+resource "aws_route53_zone" "artichoke_run" {
+  name = "artichoke.run"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+module "artichoke_run_github_challenge" {
+  source   = "../modules/github-domain-verification"
+  for_each = { for conf in local.artichoke_run_github_challenges : "${conf.org}_${conf.domain}" => conf }
+
+  zone_id             = aws_route53_zone.artichoke_run.zone_id
+  github_organization = each.value.org
+  domain              = each.value.domain
+  challenge           = each.value.challenge
+}
+
+module "artichoke_run_github_pages_challenge" {
+  source = "../modules/github-pages-domain-verification"
+
+  zone_id             = aws_route53_zone.artichoke_run.zone_id
+  github_organization = "artichoke"
+  domain              = "artichoke.run"
+  challenge           = "485977220be94c7ea6d333d5011d0c"
+}
+
+module "artichoke_run_github_pages" {
+  source = "../modules/github-pages-domain-dns"
+
+  zone_id             = aws_route53_zone.artichoke_run.zone_id
+  github_organization = "artichoke"
+}
+
+module "rubyconf2019_artichoke_run_github_pages" {
+  source = "../modules/github-pages-subdomain-dns"
+
+  zone_id             = aws_route53_zone.artichoke_run.zone_id
+  subdomain           = "rubyconf2019"
+  github_organization = "artichoke"
+}

--- a/docs/domains.md
+++ b/docs/domains.md
@@ -2,13 +2,13 @@
 
 ## Domain Names
 
-| Domain            | Registrar      | DNS             | DNSSEC? | MX Records[^1]? |
-| ----------------- | -------------- | --------------- | ------- | --------------- |
-| artichoke.run     | Google Domains | Google Domains  | ❌      | ❌              |
-| artichokeruby.com | Google Domains | Amazon Route 53 | ❌      | ❌              |
-| artichokeruby.net | Google Domains | Amazon Route 53 | ❌      | ❌              |
-| artichokeruby.org | Google Domains | Google Domains  | ❌      | ✅              |
-| artichokeruby.run | Google Domains | Amazon Route 53 | ❌      | ❌              |
+| Domain            | Registrar               | DNS             | DNSSEC? | MX Records[^1]? |
+| ----------------- | ----------------------- | --------------- | ------- | --------------- |
+| artichoke.run     | Google Domains          | Amazon Route 53 | ❌      | ❌              |
+| artichokeruby.com | Amazon Route 53 Domains | Amazon Route 53 | ❌      | ❌              |
+| artichokeruby.net | Amazon Route 53 Domains | Amazon Route 53 | ❌      | ❌              |
+| artichokeruby.org | Google Domains          | Google Domains  | ❌      | ✅              |
+| artichokeruby.run | Amazon Route 53 Domains | Amazon Route 53 | ❌      | ❌              |
 
 [^1]: MX records are also linked to a Google Workspace account.
 

--- a/modules/github-pages-domain-dns/main.tf
+++ b/modules/github-pages-domain-dns/main.tf
@@ -1,4 +1,4 @@
-data "aws_route53_zone" "zone" {
+data "aws_route53_zone" "this" {
   zone_id = var.zone_id
 }
 
@@ -10,8 +10,8 @@ data "aws_route53_zone" "zone" {
 # https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site
 
 resource "aws_route53_record" "apex_ipv4" {
-  zone_id = aws_route53_zone.this.zone_id
-  name    = aws_route53_zone.this.name
+  zone_id = data.aws_route53_zone.this.zone_id
+  name    = data.aws_route53_zone.this.name
   type    = "A"
   ttl     = "300"
 
@@ -28,8 +28,8 @@ resource "aws_route53_record" "apex_ipv4" {
 }
 
 resource "aws_route53_record" "apex_ipv6" {
-  zone_id = aws_route53_zone.this.zone_id
-  name    = aws_route53_zone.this.name
+  zone_id = data.aws_route53_zone.this.zone_id
+  name    = data.aws_route53_zone.this.name
   type    = "AAAA"
   ttl     = "300"
 
@@ -46,7 +46,7 @@ resource "aws_route53_record" "apex_ipv6" {
 }
 
 resource "aws_route53_record" "www_cname" {
-  zone_id = aws_route53_zone.this.zone_id
+  zone_id = data.aws_route53_zone.this.zone_id
   name    = "www"
   type    = "CNAME"
   ttl     = "300"

--- a/modules/github-pages-subdomain-dns/README.md
+++ b/modules/github-pages-subdomain-dns/README.md
@@ -7,7 +7,7 @@ Route53 zone to setup GitHub pages for the given subdomain.
 
 ```terraform
 module "codecov_artichokeruby_org_github_pages" {
-  source = "../modules/github-pages-domain-dns"
+  source = "../modules/github-pages-subdomain-dns"
 
   zone_id             = aws_route53_zone.this.zone_id
   subdomain           = "codecov"

--- a/modules/github-pages-subdomain-dns/main.tf
+++ b/modules/github-pages-subdomain-dns/main.tf
@@ -1,11 +1,11 @@
-data "aws_route53_zone" "zone" {
+data "aws_route53_zone" "this" {
   zone_id = var.zone_id
 }
 
 # https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site
 
 resource "aws_route53_record" "www_cname" {
-  zone_id = aws_route53_zone.this.zone_id
+  zone_id = data.aws_route53_zone.this.zone_id
   name    = var.subdomain
   type    = "CNAME"
   ttl     = "300"


### PR DESCRIPTION
these changes are applied, domains are newly verified in @artichoke-ruby organization.

See https://github.com/artichoke/project-infrastructure/issues/519