### PR TITLE
Upgrade all repositories to Ruby 3.3.0

### DIFF
--- a/github-org-artichoke/repository_file_ruby_version.tf
+++ b/github-org-artichoke/repository_file_ruby_version.tf
@@ -1,5 +1,5 @@
 locals {
-  force_bump_ruby_version = false
+  force_bump_ruby_version = true
 
   // https://github.com/ruby/ruby/tree/v3_3_0
   ruby_version = "3.3.0"

--- a/github-org-artichoke/repository_file_ruby_version.tf
+++ b/github-org-artichoke/repository_file_ruby_version.tf
@@ -6,12 +6,13 @@ locals {
 
   ruby_version_repos = [
     "artichoke",                // https://github.com/artichoke/artichoke
-    "artichoke.github.io",      // https://github.com/artichoke/artichoke.github.io
     "boba",                     // https://github.com/artichoke/boba
     "cactusref",                // https://github.com/artichoke/cactusref
     "docker-artichoke-nightly", // https://github.com/artichoke/docker-artichoke-nightly
     "focaccia",                 // https://github.com/artichoke/focaccia
+    "generate_third_party",     // https://github.com/artichoke/generate_third_party
     "intaglio",                 // https://github.com/artichoke/intaglio
+    "known-folders-rs",         // https://github.com/artichoke/known-folders-rs
     "nightly",                  // https://github.com/artichoke/nightly
     "playground",               // https://github.com/artichoke/playground
     "posix-space",              // https://github.com/artichoke/posix-space
@@ -22,8 +23,10 @@ locals {
     "roe",                      // https://github.com/artichoke/roe
     "rubyconf",                 // https://github.com/artichoke/rubyconf
     "ruby-file-expand-path",    // https://github.com/artichoke/ruby-file-expand-path
+    "setup-rust",               // https://github.com/artichoke/setup-rust
     "strftime-ruby",            // https://github.com/artichoke/strftime-ruby
     "strudel",                  // https://github.com/artichoke/strudel
+    "sysdir-rs",                // https://github.com/artichoke/sysdir-rs
   ]
 }
 

--- a/github-org-artichoke/repository_file_ruby_version.tf
+++ b/github-org-artichoke/repository_file_ruby_version.tf
@@ -1,5 +1,5 @@
 locals {
-  force_bump_ruby_version = true
+  force_bump_ruby_version = false
 
   // https://github.com/ruby/ruby/tree/v3_3_0
   ruby_version = "3.3.0"

--- a/github-org-artichoke/repository_file_ruby_version.tf
+++ b/github-org-artichoke/repository_file_ruby_version.tf
@@ -1,8 +1,8 @@
 locals {
   force_bump_ruby_version = false
 
-  // https://github.com/ruby/ruby/tree/v3_2_2
-  ruby_version = "3.2.2"
+  // https://github.com/ruby/ruby/tree/v3_3_0
+  ruby_version = "3.3.0"
 
   ruby_version_repos = [
     "artichoke",                // https://github.com/artichoke/artichoke


### PR DESCRIPTION
Merry Christmas! 🎄 💎

https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/

## Deployments

- https://github.com/artichoke/artichoke/pull/2668
- https://github.com/artichoke/boba/pull/224
- https://github.com/artichoke/cactusref/pull/193
- https://github.com/artichoke/docker-artichoke-nightly/pull/189
- https://github.com/artichoke/focaccia/pull/212
- https://github.com/artichoke/generate_third_party/pull/133
- https://github.com/artichoke/intaglio/pull/254
- https://github.com/artichoke/known-folders-rs/pull/32
- https://github.com/artichoke/nightly/pull/213
- https://github.com/artichoke/playground/pull/1117
- https://github.com/artichoke/posix-space/pull/64
- https://github.com/artichoke/project-infrastructure/pull/588
- https://github.com/artichoke/qed/pull/83
- https://github.com/artichoke/rand_mt/pull/221
- https://github.com/artichoke/raw-parts/pull/109
- https://github.com/artichoke/roe/pull/158
- https://github.com/artichoke/ruby-file-expand-path/pull/87
- https://github.com/artichoke/rubyconf/pull/536
- https://github.com/artichoke/setup-rust/pull/77
- https://github.com/artichoke/strftime-ruby/pull/122
- https://github.com/artichoke/strudel/pull/176
- https://github.com/artichoke/sysdir-rs/pull/29