### PR TITLE
Purge vestigial eslint config from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,18 +19,6 @@
   "devDependencies": {
     "prettier": "^3.4.1"
   },
-  "eslintConfig": {
-    "env": {
-      "browser": true,
-      "commonjs": true,
-      "es6": true,
-      "node": true
-    },
-    "parserOptions": {
-      "ecmaVersion": 2020,
-      "sourceType": "module"
-    }
-  },
   "scripts": {
     "fmt": "prettier --write \"**/*\""
   }


### PR DESCRIPTION
This is a copy-paste legacy. This repo does not use eslint. This config is not valid for the latest version of eslint@9.