### PR TITLE
Fix template injection in code coverage action

### DIFF
--- a/github-org-artichoke/templates/rust-code-coverage.yaml
+++ b/github-org-artichoke/templates/rust-code-coverage.yaml
@@ -20,10 +20,12 @@ jobs:
       CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3.5.2
+        uses: actions/checkout@v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Install nightly Rust toolchain
-        uses: artichoke/setup-rust/code-coverage@v1.9.0
+        uses: artichoke/setup-rust/code-coverage@v1.12.1
 
       - name: Setup grcov
         run: |
@@ -61,7 +63,7 @@ jobs:
         run: grcov ${github_repository}*.profraw --source-dir . --keep-only 'src/**/*.rs' --binary-path target/debug -t covdir --filter covered -o target/coverage/coverage.json
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@e1e17a757e536f70e52b5a12b2e8d1d1c60e04ef # v2.0.0
+        uses: aws-actions/configure-aws-credentials@4fc4975a852c8cd99761e2de1f4ba73402e44dd9 # v4.0.3
         if: github.ref == 'refs/heads/trunk'
         with:
           aws-region: us-west-2
@@ -82,8 +84,13 @@ jobs:
 
       - name: Check missed lines
         shell: python
+        env:
+          GITHUB_REF_NAME: $${{ github.ref_name }}
+          GITHUB_EVENT_NAME: $${{ github.event_name }}
+          GITHUB_EVENT_NUMBER: $${{ github.event.number }}
         run: |
           import json
+          import os
           from urllib.request import urlopen
 
           trunk_coverage_url = "https://codecov.artichokeruby.org/${github_repository}/coverage.json"
@@ -101,7 +108,7 @@ jobs:
               print("")
 
 
-          if "$${{ github.ref_name }}" == "trunk":
+          if os.environ.get("GITHUB_REF_NAME") == "trunk":
               # We don't need to compare trunk coverage to itself
               exit(0)
 
@@ -114,8 +121,8 @@ jobs:
               branch_coverage = json.load(local)
 
           on = None
-          if "$${{ github.event_name }}" == "pull_request":
-              on = "PR artichoke/${github_repository}#$${{ github.event.number }}"
+          if os.environ.get("GITHUB_EVENT_NAME") == "pull_request":
+              on = "PR artichoke/${github_repository}#" + os.environ.get("GITHUB_EVENT_NUMBER")
 
           print_report(branch_coverage, on=on)
 


### PR DESCRIPTION
Address these zizmor findings:

```console
$ zizmor .github/workflows/code-coverage.yaml
2025-02-02T00:10:03.694628Z  INFO zizmor: skipping impostor-commit: can't run without a GitHub API token
2025-02-02T00:10:03.694659Z  INFO zizmor: skipping ref-confusion: can't run without a GitHub API token
2025-02-02T00:10:03.694670Z  INFO zizmor: skipping known-vulnerable-actions: can't run without a GitHub API token
2025-02-02T00:10:03.723952Z  INFO audit: zizmor: 🌈 completed .github/workflows/code-coverage.yaml
warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> .github/workflows/code-coverage.yaml:22:9
   |
22 |         - name: Checkout repository
   |  _________-
23 | |         uses: actions/checkout@v4.2.2
   | |_____________________________________- does not set persist-credentials: false
   |
   = note: audit confidence → Low

error[template-injection]: code injection via template expansion
   --> .github/workflows/code-coverage.yaml:83:9
    |
 83 |         - name: Check missed lines
    |           ^^^^^^^^^^^^^^^^^^^^^^^^ this step
 84 |           shell: python
 85 | /         run: |
 86 | |           import json
...   |
122 | |           is_ok = branch_coverage["linesMissed"] <= trunk_coverage["linesMissed"]
123 | |           exit(0) if is_ok else exit(1)
    | |________________________________________^ github.ref_name may expand into attacker-controllable code
    |
    = note: audit confidence → High

5 findings (3 suppressed): 0 unknown, 0 informational, 0 low, 1 medium, 1 high
```

This terraform change has already been deployed org-wide:

- https://github.com/artichoke/boba/pull/265
- https://github.com/artichoke/focaccia/pull/256
- https://github.com/artichoke/intaglio/pull/297
- https://github.com/artichoke/posix-space/pull/106
- https://github.com/artichoke/rand_mt/pull/264
- https://github.com/artichoke/raw-parts/pull/154
- https://github.com/artichoke/roe/pull/202
- https://github.com/artichoke/strftime-ruby/pull/165