### PR TITLE
Migrate artichokeruby.org DNS to Route53

### DIFF
--- a/aws/dns_artichoke.run.tf
+++ b/aws/dns_artichoke.run.tf
@@ -12,19 +12,15 @@ locals {
   ]
 }
 
-resource "aws_route53_zone" "artichoke_run" {
+data "aws_route53_zone" "artichoke_run" {
   name = "artichoke.run"
-
-  lifecycle {
-    prevent_destroy = true
-  }
 }
 
 module "artichoke_run_github_challenge" {
   source   = "../modules/github-domain-verification"
   for_each = { for conf in local.artichoke_run_github_challenges : "${conf.org}_${conf.domain}" => conf }
 
-  zone_id             = aws_route53_zone.artichoke_run.zone_id
+  zone_id             = data.aws_route53_zone.artichoke_run.zone_id
   github_organization = each.value.org
   domain              = each.value.domain
   challenge           = each.value.challenge
@@ -33,7 +29,7 @@ module "artichoke_run_github_challenge" {
 module "artichoke_run_github_pages_challenge" {
   source = "../modules/github-pages-domain-verification"
 
-  zone_id             = aws_route53_zone.artichoke_run.zone_id
+  zone_id             = data.aws_route53_zone.artichoke_run.zone_id
   github_organization = "artichoke"
   domain              = "artichoke.run"
   challenge           = "485977220be94c7ea6d333d5011d0c"
@@ -42,14 +38,14 @@ module "artichoke_run_github_pages_challenge" {
 module "artichoke_run_github_pages" {
   source = "../modules/github-pages-domain-dns"
 
-  zone_id             = aws_route53_zone.artichoke_run.zone_id
+  zone_id             = data.aws_route53_zone.artichoke_run.zone_id
   github_organization = "artichoke"
 }
 
 module "rubyconf2019_artichoke_run_github_pages" {
   source = "../modules/github-pages-subdomain-dns"
 
-  zone_id             = aws_route53_zone.artichoke_run.zone_id
+  zone_id             = data.aws_route53_zone.artichoke_run.zone_id
   subdomain           = "rubyconf2019"
   github_organization = "artichoke"
 }
@@ -57,7 +53,7 @@ module "rubyconf2019_artichoke_run_github_pages" {
 module "artichoke_run_google" {
   source = "../modules/google-site-verification"
 
-  zone_id = aws_route53_zone.artichoke_run.zone_id
+  zone_id = data.aws_route53_zone.artichoke_run.zone_id
 
   site_verification_keys = [
     "Ro-ABr2TIv3obx8csab8E3NC43BrANBdXimBKg2Jcxc", # Google Search Console

--- a/aws/dns_artichokeruby.com.tf
+++ b/aws/dns_artichokeruby.com.tf
@@ -9,19 +9,15 @@ locals {
   ]
 }
 
-resource "aws_route53_zone" "artichokeruby_com" {
+data "aws_route53_zone" "artichokeruby_com" {
   name = "artichokeruby.com"
-
-  lifecycle {
-    prevent_destroy = true
-  }
 }
 
 module "artichokeruby_com_github_challenge" {
   source   = "../modules/github-domain-verification"
   for_each = { for conf in local.artichokeruby_com_github_challenges : "${conf.org}_${conf.domain}" => conf }
 
-  zone_id             = aws_route53_zone.artichokeruby_com.zone_id
+  zone_id             = data.aws_route53_zone.artichokeruby_com.zone_id
   github_organization = each.value.org
   domain              = each.value.domain
   challenge           = each.value.challenge
@@ -30,7 +26,7 @@ module "artichokeruby_com_github_challenge" {
 module "artichokeruby_com_github_pages_challenge" {
   source = "../modules/github-pages-domain-verification"
 
-  zone_id             = aws_route53_zone.artichokeruby_com.zone_id
+  zone_id             = data.aws_route53_zone.artichokeruby_com.zone_id
   github_organization = "artichoke"
   domain              = "artichokeruby.com"
   challenge           = "cef8b209bccd79f7df0f51b877bd9e"
@@ -41,7 +37,7 @@ module "artichokeruby_com_redirect" {
 
   access_logs_bucket = module.forge_access_logs.name
 
-  zone_id     = aws_route53_zone.artichokeruby_com.zone_id
+  zone_id     = data.aws_route53_zone.artichokeruby_com.zone_id
   redirect_to = "https://www.artichokeruby.org"
 
   providers = {

--- a/aws/dns_artichokeruby.net.tf
+++ b/aws/dns_artichokeruby.net.tf
@@ -9,19 +9,15 @@ locals {
   ]
 }
 
-resource "aws_route53_zone" "artichokeruby_net" {
+data "aws_route53_zone" "artichokeruby_net" {
   name = "artichokeruby.net"
-
-  lifecycle {
-    prevent_destroy = true
-  }
 }
 
 module "artichokeruby_net_github_challenge" {
   source   = "../modules/github-domain-verification"
   for_each = { for conf in local.artichokeruby_net_github_challenges : "${conf.org}_${conf.domain}" => conf }
 
-  zone_id             = aws_route53_zone.artichokeruby_net.zone_id
+  zone_id             = data.aws_route53_zone.artichokeruby_net.zone_id
   github_organization = each.value.org
   domain              = each.value.domain
   challenge           = each.value.challenge
@@ -30,7 +26,7 @@ module "artichokeruby_net_github_challenge" {
 module "artichokeruby_net_github_pages_challenge" {
   source = "../modules/github-pages-domain-verification"
 
-  zone_id             = aws_route53_zone.artichokeruby_net.zone_id
+  zone_id             = data.aws_route53_zone.artichokeruby_net.zone_id
   github_organization = "artichoke"
   domain              = "artichokeruby.net"
   challenge           = "7da729a45019ca339d0cedce912c2e"
@@ -41,7 +37,7 @@ module "artichokeruby_net_redirect" {
 
   access_logs_bucket = module.forge_access_logs.name
 
-  zone_id     = aws_route53_zone.artichokeruby_net.zone_id
+  zone_id     = data.aws_route53_zone.artichokeruby_net.zone_id
   redirect_to = "https://www.artichokeruby.org"
 
   providers = {

--- a/aws/dns_artichokeruby.org.tf
+++ b/aws/dns_artichokeruby.org.tf
@@ -1,0 +1,93 @@
+locals {
+  artichokeruby_org_github_challenges = [
+    { org = "artichoke", domain = "artichokeruby.org", challenge = "c8065f2679" },
+    { org = "artichoke", domain = "www.artichokeruby.org", challenge = "fdd9b51f12" },
+    { org = "artichokeruby", domain = "artichokeruby.org", challenge = "e0a404f8a5" },
+    { org = "artichokeruby", domain = "www.artichokeruby.org", challenge = "0aa1ad5148" },
+    { org = "artichoke-ruby", domain = "artichokeruby.org", challenge = "f80b5a8055" },
+    { org = "artichoke-ruby", domain = "www.artichokeruby.org", challenge = "4d9e15be0c" },
+  ]
+}
+
+data "aws_route53_zone" "artichokeruby_org" {
+  name = "artichokeruby.org"
+}
+
+module "artichokeruby_org_github_challenge" {
+  source   = "../modules/github-domain-verification"
+  for_each = { for conf in local.artichokeruby_org_github_challenges : "${conf.org}_${conf.domain}" => conf }
+
+  zone_id             = data.aws_route53_zone.artichokeruby_org.zone_id
+  github_organization = each.value.org
+  domain              = each.value.domain
+  challenge           = each.value.challenge
+}
+
+module "artichokeruby_org_github_pages_challenge" {
+  source = "../modules/github-pages-domain-verification"
+
+  zone_id             = data.aws_route53_zone.artichokeruby_org.zone_id
+  github_organization = "artichoke"
+  domain              = "artichokeruby.org"
+  challenge           = "35fc238d3171df6cf54e3c2b07c195"
+}
+
+module "artichokeruby_org_redirect" {
+  source = "../modules/domain-redirect"
+
+  access_logs_bucket = module.forge_access_logs.name
+
+  zone_id     = data.aws_route53_zone.artichokeruby_org.zone_id
+  redirect_to = "https://www.artichokeruby.org"
+  apex_only   = true
+
+  providers = {
+    aws           = aws
+    aws.us_east_1 = aws.us_east_1
+  }
+}
+
+resource "aws_route53_record" "artichokeruby_org_www" {
+  zone_id = data.aws_route53_zone.artichokeruby_org.zone_id
+  name    = "www.artichokeruby.org"
+  type    = "CNAME"
+  ttl     = 300
+  records = [
+    "artichoke.github.io",
+  ]
+}
+
+resource "aws_route53_record" "artichokeruby_org_codecov_ipv4" {
+  zone_id = data.aws_route53_zone.artichokeruby_org.zone_id
+  name    = "codecov.artichokeruby.org"
+  type    = "A"
+
+  alias {
+    name                   = module.code_coverage.cloudfront_domain_name
+    zone_id                = module.code_coverage.cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "artichokeruby_org_codecov_ipv6" {
+  zone_id = data.aws_route53_zone.artichokeruby_org.zone_id
+  name    = "codecov.artichokeruby.org"
+  type    = "AAAA"
+
+  alias {
+    name                   = module.code_coverage.cloudfront_domain_name
+    zone_id                = module.code_coverage.cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
+module "artichokeruby_org_google_workspace" {
+  source = "../modules/google-workspace"
+
+  zone_id     = data.aws_route53_zone.artichokeruby_org.zone_id
+  dkim_record = "v=DKIM1; k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAk3sMJuaFn/1lBZYWTc33CVQXtP8DAzP95vvwsN9V9iyU5Wyar7wUl514QSBzbDJgxF+VVfODy0KX/IcaelPsK67LxIfwk6HWVSfniUXbta5XPm5HTSFssNNoDuGRujdT3hFzecoMF/aWYR5TXjcM1ICt1U6kmfWB03quZXyZ0Y2YnaNGlv3hb+dWr58IZGuvA48TOmNVuFcQKsuz7sLOdkAA9AxCnDCkiMuV72SMbUq7Da0afLxObiYl9CN3J52qDp1qaxaGYU+2yie8+45IzihudYCEBuw8J8HXgRfcnqfmSscywlOPMk6HH8HYqZqPkKqd7mAmksWkDixY6rVMHQIDAQAB"
+
+  site_verification_keys = [
+    "WNbmzcJDc3Umb4SquyIhK5k-juY5IQj7RUe0ulAbrGY",
+  ]
+}

--- a/aws/dns_artichokeruby.run.tf
+++ b/aws/dns_artichokeruby.run.tf
@@ -9,19 +9,15 @@ locals {
   ]
 }
 
-resource "aws_route53_zone" "artichokeruby_run" {
+data "aws_route53_zone" "artichokeruby_run" {
   name = "artichokeruby.run"
-
-  lifecycle {
-    prevent_destroy = true
-  }
 }
 
 module "artichokeruby_run_github_challenge" {
   source   = "../modules/github-domain-verification"
   for_each = { for conf in local.artichokeruby_run_github_challenges : "${conf.org}_${conf.domain}" => conf }
 
-  zone_id             = aws_route53_zone.artichokeruby_run.zone_id
+  zone_id             = data.aws_route53_zone.artichokeruby_run.zone_id
   github_organization = each.value.org
   domain              = each.value.domain
   challenge           = each.value.challenge
@@ -30,7 +26,7 @@ module "artichokeruby_run_github_challenge" {
 module "artichokeruby_run_github_pages_challenge" {
   source = "../modules/github-pages-domain-verification"
 
-  zone_id             = aws_route53_zone.artichokeruby_run.zone_id
+  zone_id             = data.aws_route53_zone.artichokeruby_run.zone_id
   github_organization = "artichoke"
   domain              = "artichokeruby.run"
   challenge           = "50369d1a13ec11c0d9899705388810"
@@ -41,7 +37,7 @@ module "artichokeruby_run_redirect" {
 
   access_logs_bucket = module.forge_access_logs.name
 
-  zone_id     = aws_route53_zone.artichokeruby_run.zone_id
+  zone_id     = data.aws_route53_zone.artichokeruby_run.zone_id
   redirect_to = "https://artichoke.run"
 
   providers = {

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -72,6 +72,7 @@ module "code_coverage" {
   access_logs_bucket = module.forge_access_logs.name
 
   domains = ["codecov.artichokeruby.org"]
+  zone_id = data.aws_route53_zone.artichokeruby_org.zone_id
 
   providers = {
     aws           = aws

--- a/modules/access-logs-s3-bucket/main.tf
+++ b/modules/access-logs-s3-bucket/main.tf
@@ -22,6 +22,9 @@ resource "aws_s3_bucket_lifecycle_configuration" "this" {
     id     = "archive"
     status = "Enabled"
 
+    # match every object in the bucket
+    filter {}
+
     transition {
       days          = 30
       storage_class = "STANDARD_IA"

--- a/modules/domain-redirect/README.md
+++ b/modules/domain-redirect/README.md
@@ -39,6 +39,8 @@ module "redirect" {
 - `zone_id`: The id of the Route53 zone to create redirect records in.
 - `redirect_to`: The website to redirect to, should be of the format
   `https://example.com/`.
+- `apex_only`: Whether the redirect is only for the apex domain in the given
+  zone.
 
 ## Outputs
 

--- a/modules/domain-redirect/main.tf
+++ b/modules/domain-redirect/main.tf
@@ -1,6 +1,6 @@
 locals {
   apex_domain      = data.aws_route53_zone.zone.name
-  redirect_domains = [local.apex_domain, "www.${local.apex_domain}"]
+  redirect_domains = var.apex_only ? [local.apex_domain] : [local.apex_domain, "www.${local.apex_domain}"]
   safe_name        = replace(local.apex_domain, ".", "-")
   bucket           = "artichoke-domain-redirect-${local.safe_name}"
 }
@@ -46,6 +46,8 @@ resource "aws_route53_record" "apex_ipv6" {
 }
 
 resource "aws_route53_record" "www_ipv4" {
+  for_each = var.apex_only ? toset([]) : toset(["enabled"])
+
   zone_id = data.aws_route53_zone.zone.zone_id
   name    = "www"
   type    = "A"
@@ -58,6 +60,8 @@ resource "aws_route53_record" "www_ipv4" {
 }
 
 resource "aws_route53_record" "www_ipv6" {
+  for_each = var.apex_only ? toset([]) : toset(["enabled"])
+
   zone_id = data.aws_route53_zone.zone.zone_id
   name    = "www"
   type    = "AAAA"
@@ -83,6 +87,9 @@ resource "aws_s3_bucket_lifecycle_configuration" "this" {
   rule {
     id     = "archive"
     status = "Enabled"
+
+    # match every object in the bucket
+    filter {}
 
     noncurrent_version_transition {
       noncurrent_days = 30

--- a/modules/domain-redirect/variables.tf
+++ b/modules/domain-redirect/variables.tf
@@ -26,3 +26,9 @@ variable "redirect_to" {
     error_message = "Redirect target must be a URL that does not end in `/`."
   }
 }
+
+variable "apex_only" {
+  description = "Whether the redirect is only for the apex domain"
+  type        = bool
+  default     = false
+}

--- a/modules/google-workspace-mx/main.tf
+++ b/modules/google-workspace-mx/main.tf
@@ -3,9 +3,6 @@ data "aws_route53_zone" "zone" {
 }
 
 # G Suite MX record values: https://support.google.com/a/answer/174125?hl=en
-#
-# Use "I signed up before 2023" configuration.
-
 resource "aws_route53_record" "this" {
   zone_id = data.aws_route53_zone.zone.zone_id
   name    = data.aws_route53_zone.zone.name
@@ -13,11 +10,7 @@ resource "aws_route53_record" "this" {
   ttl     = "3600"
 
   records = [
-    "1 ASPMX.L.GOOGLE.COM.",
-    "5 ALT1.ASPMX.L.GOOGLE.COM.",
-    "5 ALT2.ASPMX.L.GOOGLE.COM.",
-    "10 ALT3.ASPMX.L.GOOGLE.COM.",
-    "10 ALT4.ASPMX.L.GOOGLE.COM.",
+    "1 smtp.google.com.",
   ]
 
   lifecycle {

--- a/modules/private-archive-s3-bucket/main.tf
+++ b/modules/private-archive-s3-bucket/main.tf
@@ -22,6 +22,9 @@ resource "aws_s3_bucket_lifecycle_configuration" "this" {
     id     = "archive"
     status = "Enabled"
 
+    # match every object in the bucket
+    filter {}
+
     transition {
       days          = 30
       storage_class = "GLACIER_IR"

--- a/modules/private-s3-bucket/main.tf
+++ b/modules/private-s3-bucket/main.tf
@@ -22,6 +22,9 @@ resource "aws_s3_bucket_lifecycle_configuration" "this" {
     id     = "archive"
     status = "Enabled"
 
+    # match every object in the bucket
+    filter {}
+
     noncurrent_version_transition {
       noncurrent_days = 30
       storage_class   = "GLACIER_IR"

--- a/modules/s3-bucket-website-codecov/README.md
+++ b/modules/s3-bucket-website-codecov/README.md
@@ -35,6 +35,7 @@ module "code_coverage" {
   destination.
 - `domains`: List of domain names included in the ACM certificate and CloudFront
   distribution.
+- `zone_id`: The Route53 zone to use for ACM DNS validation.
 
 ## Outputs
 

--- a/modules/s3-bucket-website-codecov/main.tf
+++ b/modules/s3-bucket-website-codecov/main.tf
@@ -22,6 +22,9 @@ resource "aws_s3_bucket_lifecycle_configuration" "this" {
     id     = "archive"
     status = "Enabled"
 
+    # match every object in the bucket
+    filter {}
+
     noncurrent_version_transition {
       noncurrent_days = 30
       storage_class   = "GLACIER_IR"
@@ -91,16 +94,51 @@ resource "aws_acm_certificate" "cert" {
 
   domain_name               = var.domains[0]
   subject_alternative_names = slice(var.domains, 1, length(var.domains))
-  validation_method         = "EMAIL"
-
-  validation_option {
-    domain_name       = var.domains[0]
-    validation_domain = "artichokeruby.org"
-  }
+  validation_method         = "DNS"
 
   options {
     certificate_transparency_logging_preference = "ENABLED"
   }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+data "aws_route53_zone" "cert" {
+  zone_id      = var.zone_id
+  private_zone = false
+}
+
+resource "aws_route53_record" "cert_validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.cert.domain_validation_options :
+    dvo.domain_name => {
+      name    = dvo.resource_record_name
+      type    = dvo.resource_record_type
+      record  = dvo.resource_record_value
+      zone_id = data.aws_route53_zone.cert.zone_id
+    }
+  }
+
+  name    = each.value.name
+  type    = each.value.type
+  zone_id = each.value.zone_id
+  records = [each.value.record]
+  ttl     = 300
+
+  lifecycle {
+    create_before_destroy = false
+  }
+}
+
+resource "aws_acm_certificate_validation" "cert" {
+  provider        = aws.us_east_1
+  certificate_arn = aws_acm_certificate.cert.arn
+
+  validation_record_fqdns = [
+    for rec in aws_route53_record.cert_validation : rec.fqdn
+  ]
 
   lifecycle {
     create_before_destroy = true

--- a/modules/s3-bucket-website-codecov/outputs.tf
+++ b/modules/s3-bucket-website-codecov/outputs.tf
@@ -17,3 +17,18 @@ output "cloudfront_domain_name" {
   description = "The domain name corresponding to the CloudFront distribution"
   value       = aws_cloudfront_distribution.website.domain_name
 }
+
+output "cloudfront_distribution_id" {
+  description = "The ID of the CloudFront distribution"
+  value       = aws_cloudfront_distribution.website.id
+}
+
+output "cloudfront_arn" {
+  description = "The ARN of the CloudFront distribution"
+  value       = aws_cloudfront_distribution.website.arn
+}
+
+output "cloudfront_zone_id" {
+  description = "The hosted zone ID of the CloudFront distribution"
+  value       = aws_cloudfront_distribution.website.hosted_zone_id
+}

--- a/modules/s3-bucket-website-codecov/variables.tf
+++ b/modules/s3-bucket-website-codecov/variables.tf
@@ -16,3 +16,8 @@ variable "domains" {
     error_message = "Domain must be a superdomain of artichokeruby.org."
   }
 }
+
+variable "zone_id" {
+  description = "The ID of the Route 53 hosted zone to use for ACM DNS validation"
+  type        = string
+}


### PR DESCRIPTION
Closes #519.

Ready to move the last Artichoke domain away from Squarespace (only took 2+ years :grimacing:)

Also:

- Address terraform warnings for missing `filter` blocks in AWS S3 bucket lifecycle config.
- Switch codecov ACM cert for Cloudfront distribution to DNS validation.
- Update all DNS provisioning in `//aws/` plan to grab zones with a data provider since the zones are provisioned in `//terraform/projects/route53-dns`.
- Allow the domain redirect module to operate in 'apex only' mode so it can be used to redirect `artichokeruby.org -> www.artichokeruby.org`, replacing the Squarespace (previously Google Domains) redirect from apex to `www`.
- Update Google MX records to modern single `smtp.google.com` value.