### PR TITLE
terraform: GitHub repo maintenance and S3 locking for remote state

### DIFF
--- a/aws/main.tf
+++ b/aws/main.tf
@@ -1,10 +1,10 @@
 terraform {
   backend "s3" {
-    bucket         = "artichoke-forge-project-infrastructure-terraform-state"
-    region         = "us-west-2"
-    key            = "aws/terraform.tfstate"
-    encrypt        = true
-    dynamodb_table = "terraform_statelock"
+    bucket       = "artichoke-forge-project-infrastructure-terraform-state"
+    region       = "us-west-2"
+    key          = "aws/terraform.tfstate"
+    encrypt      = true
+    use_lockfile = true
   }
 }
 

--- a/github-org-artichoke-ruby/main.tf
+++ b/github-org-artichoke-ruby/main.tf
@@ -1,10 +1,10 @@
 terraform {
   backend "s3" {
-    bucket         = "artichoke-forge-project-infrastructure-terraform-state"
-    region         = "us-west-2"
-    key            = "github-org-artichoke-ruby/terraform.tfstate"
-    encrypt        = true
-    dynamodb_table = "terraform_statelock"
+    bucket       = "artichoke-forge-project-infrastructure-terraform-state"
+    region       = "us-west-2"
+    key          = "github-org-artichoke-ruby/terraform.tfstate"
+    encrypt      = true
+    use_lockfile = true
   }
 }
 

--- a/github-org-artichoke/main.tf
+++ b/github-org-artichoke/main.tf
@@ -1,10 +1,10 @@
 terraform {
   backend "s3" {
-    bucket         = "artichoke-forge-project-infrastructure-terraform-state"
-    region         = "us-west-2"
-    key            = "github/terraform.tfstate"
-    encrypt        = true
-    dynamodb_table = "terraform_statelock"
+    bucket       = "artichoke-forge-project-infrastructure-terraform-state"
+    region       = "us-west-2"
+    key          = "github/terraform.tfstate"
+    encrypt      = true
+    use_lockfile = true
   }
 }
 
@@ -17,11 +17,11 @@ data "terraform_remote_state" "aws" {
   backend = "s3"
 
   config = {
-    bucket         = "artichoke-forge-project-infrastructure-terraform-state"
-    region         = "us-west-2"
-    key            = "aws/terraform.tfstate"
-    encrypt        = true
-    dynamodb_table = "terraform_statelock"
+    bucket       = "artichoke-forge-project-infrastructure-terraform-state"
+    region       = "us-west-2"
+    key          = "aws/terraform.tfstate"
+    encrypt      = true
+    use_lockfile = true
   }
 }
 

--- a/github-org-artichoke/repos_active.tf
+++ b/github-org-artichoke/repos_active.tf
@@ -165,26 +165,6 @@ module "github_intaglio" {
   ]
 }
 
-module "github_jasper" {
-  source = "../modules/github-repository"
-
-  name         = "jasper"
-  description  = "🧳 Single-binary packaging for Ruby applications that supports native and Wasm targets"
-  homepage_url = null
-
-  has_github_pages = false
-
-  topics = [
-    "bundler",
-    "packaging",
-    "ruby",
-    "rust",
-    "rust-application",
-    "wasm",
-    "webassembly",
-  ]
-}
-
 module "github_known_folders" {
   source = "../modules/github-repository"
 

--- a/github-org-artichoke/repos_archived.tf
+++ b/github-org-artichoke/repos_archived.tf
@@ -17,6 +17,20 @@ module "archived_artichoke_ci" {
   ]
 }
 
+module "archived_artichoke_onigmo" {
+  source = "../modules/archived-repository"
+
+  name        = "artichoke-onigmo"
+  description = "Rust port / transpilation of Onigmo"
+  visibility  = "private"
+
+  delete_branch_on_merge = false
+  has_wiki               = false
+
+  topics            = []
+  no_default_topics = true
+}
+
 module "archived_ferrocarril" {
   source = "../modules/archived-repository"
 
@@ -37,6 +51,26 @@ module "archived_ferrocarril" {
   ]
 }
 
+module "archived_jasper" {
+  source = "../modules/archived-repository"
+
+  name         = "jasper"
+  description  = "🧳 Single-binary packaging for Ruby applications that supports native and Wasm targets"
+  homepage_url = null
+
+  has_github_pages = false
+
+  topics = [
+    "bundler",
+    "packaging",
+    "ruby",
+    "rust",
+    "rust-application",
+    "wasm",
+    "webassembly",
+  ]
+}
+
 module "archived_rust_mersenne_twister" {
   source = "../modules/archived-repository"
 
@@ -50,7 +84,8 @@ module "archived_rust_mersenne_twister" {
   has_wiki               = true
 
 
-  topics = []
+  topics            = []
+  no_default_topics = true
 }
 
 module "archived_rubyconf2019_artichoke_run" {

--- a/github-org-artichokeruby/main.tf
+++ b/github-org-artichokeruby/main.tf
@@ -1,10 +1,10 @@
 terraform {
   backend "s3" {
-    bucket         = "artichoke-forge-project-infrastructure-terraform-state"
-    region         = "us-west-2"
-    key            = "github-org-artichokeruby/terraform.tfstate"
-    encrypt        = true
-    dynamodb_table = "terraform_statelock"
+    bucket       = "artichoke-forge-project-infrastructure-terraform-state"
+    region       = "us-west-2"
+    key          = "github-org-artichokeruby/terraform.tfstate"
+    encrypt      = true
+    use_lockfile = true
   }
 }
 

--- a/modules/archived-repository/README.md
+++ b/modules/archived-repository/README.md
@@ -49,6 +49,10 @@ module "archived_ferrocarril" {
 - `github_pages_cname`: CNAME record for GitHub Pages deployment, defaults to
   `null`, only has an effect if `has_github_pages` is `true`.
 - `topics`: The list of topics of the repository.
+- `no_default_topics`: Set to `true` to skip creating default topics (e.g.
+  `artichoke`).
+- `visibility`: The visibility of the repo, either `public` or `private`
+  (defaults to `public`).
 
 ## Outputs
 

--- a/modules/archived-repository/main.tf
+++ b/modules/archived-repository/main.tf
@@ -13,7 +13,7 @@ resource "github_repository" "this" {
   homepage_url = var.homepage_url
 
   archived   = true
-  visibility = "public"
+  visibility = var.visibility
 
   has_downloads = var.has_downloads
   has_issues    = var.has_issues
@@ -28,7 +28,7 @@ resource "github_repository" "this" {
   squash_merge_commit_title   = "PR_TITLE"
   squash_merge_commit_message = "PR_BODY"
 
-  topics = toset(concat(var.topics, ["artichoke"]))
+  topics = toset(concat(var.topics, var.no_default_topics ? [] : ["artichoke"]))
 
   dynamic "pages" {
     for_each = range(var.has_github_pages ? 1 : 0)

--- a/modules/archived-repository/variables.tf
+++ b/modules/archived-repository/variables.tf
@@ -66,3 +66,15 @@ variable "topics" {
   description = "The list of topics of the repository"
   type        = list(string)
 }
+
+variable "no_default_topics" {
+  description = "Set to true to prevent the creation of default topics"
+  default     = false
+  type        = bool
+}
+
+variable "visibility" {
+  description = "The visibility of the repository, either 'public' or 'private'"
+  default     = "public"
+  type        = string
+}

--- a/terraform/modules/access-logs-s3-bucket/main.tf
+++ b/terraform/modules/access-logs-s3-bucket/main.tf
@@ -13,6 +13,9 @@ resource "aws_s3_bucket_lifecycle_configuration" "this" {
     id     = "archive"
     status = "Enabled"
 
+    # match every object in the bucket
+    filter {}
+
     transition {
       days          = 14
       storage_class = "DEEP_ARCHIVE"

--- a/terraform/modules/private-s3-bucket/main.tf
+++ b/terraform/modules/private-s3-bucket/main.tf
@@ -18,6 +18,9 @@ resource "aws_s3_bucket_lifecycle_configuration" "this" {
     id     = "archive"
     status = "Enabled"
 
+    # match every object in the bucket
+    filter {}
+
     noncurrent_version_transition {
       noncurrent_days = 30
       storage_class   = "GLACIER_IR"

--- a/terraform/projects/github-actions-oidc-provider/main.tf
+++ b/terraform/projects/github-actions-oidc-provider/main.tf
@@ -1,9 +1,9 @@
 terraform {
   backend "s3" {
-    bucket         = "artichoke-forge-project-infrastructure-terraform-state"
-    region         = "us-west-2"
-    key            = "github-actions-oidc-provider/terraform.tfstate"
-    encrypt        = true
-    dynamodb_table = "terraform_statelock"
+    bucket       = "artichoke-forge-project-infrastructure-terraform-state"
+    region       = "us-west-2"
+    key          = "github-actions-oidc-provider/terraform.tfstate"
+    encrypt      = true
+    use_lockfile = true
   }
 }

--- a/terraform/projects/github-actions-terraform-linting/main.tf
+++ b/terraform/projects/github-actions-terraform-linting/main.tf
@@ -1,9 +1,9 @@
 terraform {
   backend "s3" {
-    bucket         = "artichoke-forge-project-infrastructure-terraform-state"
-    region         = "us-west-2"
-    key            = "github-actions-terraform-linting/terraform.tfstate"
-    encrypt        = true
-    dynamodb_table = "terraform_statelock"
+    bucket       = "artichoke-forge-project-infrastructure-terraform-state"
+    region       = "us-west-2"
+    key          = "github-actions-terraform-linting/terraform.tfstate"
+    encrypt      = true
+    use_lockfile = true
   }
 }

--- a/terraform/projects/remote-state/main.tf
+++ b/terraform/projects/remote-state/main.tf
@@ -1,9 +1,9 @@
 terraform {
   backend "s3" {
-    bucket         = "artichoke-forge-project-infrastructure-terraform-state"
-    region         = "us-west-2"
-    key            = "remote-state/terraform.tfstate"
-    encrypt        = true
-    dynamodb_table = "terraform_statelock"
+    bucket       = "artichoke-forge-project-infrastructure-terraform-state"
+    region       = "us-west-2"
+    key          = "remote-state/terraform.tfstate"
+    encrypt      = true
+    use_lockfile = true
   }
 }

--- a/terraform/projects/remote-state/modules/global/main.tf
+++ b/terraform/projects/remote-state/modules/global/main.tf
@@ -10,28 +10,3 @@ module "remote_state" {
   bucket             = "artichoke-forge-project-infrastructure-terraform-state"
   access_logs_bucket = module.remote_state_access_logs.name
 }
-
-# tfsec:ignore:aws-dynamodb-table-customer-key
-resource "aws_dynamodb_table" "terraform_statelock" {
-  name           = "terraform_statelock"
-  read_capacity  = 5
-  write_capacity = 5
-  hash_key       = "LockID"
-
-  point_in_time_recovery {
-    enabled = true
-  }
-
-  server_side_encryption {
-    enabled = true
-  }
-
-  attribute {
-    name = "LockID"
-    type = "S"
-  }
-
-  lifecycle {
-    prevent_destroy = true
-  }
-}

--- a/terraform/projects/route53-dns/main.tf
+++ b/terraform/projects/route53-dns/main.tf
@@ -1,9 +1,9 @@
 terraform {
   backend "s3" {
-    bucket         = "artichoke-forge-project-infrastructure-terraform-state"
-    region         = "us-west-2"
-    key            = "route53-dns/terraform.tfstate"
-    encrypt        = true
-    dynamodb_table = "terraform_statelock"
+    bucket       = "artichoke-forge-project-infrastructure-terraform-state"
+    region       = "us-west-2"
+    key          = "route53-dns/terraform.tfstate"
+    encrypt      = true
+    use_lockfile = true
   }
 }


### PR DESCRIPTION
- Update all remote state backend to use S3-native locking via `use_lockfile` and stop using the deprecated DynamoDB state lock table.
- Update calls to remote state resources to use S3 lockfile.
- Update GitHub code to reflect `jasper` repository being archived.
- Manage `artichoke-onigmo` and move to archived.
- Add missing `filter {}` blocks in S3 bucket modules in `terraform/modules/...`.
- Destroy `terraform_statelock` DynamoDB table.
- Fix drift on `rust-mersenne-twister` by adding a knob to disable inserting the `artichoke` topic on an archived repository. Also used this for the `artichoke-onigmo` repo.
- Added a knob for the archived repository module to override the default visibility to `private`.

Fixes #459.
Fixes #650.